### PR TITLE
Add the ability to configure the ignorePassiveAddress option of the FTP adapter

### DIFF
--- a/docs/3-interacting-with-ftp-and-sftp-servers.md
+++ b/docs/3-interacting-with-ftp-and-sftp-servers.md
@@ -28,6 +28,7 @@ flysystem:
                 passive: true
                 ssl: true
                 timeout: 30
+                ignorePassiveAddress: ~
 ```
 
 ## SFTP

--- a/docs/3-interacting-with-ftp-and-sftp-servers.md
+++ b/docs/3-interacting-with-ftp-and-sftp-servers.md
@@ -28,7 +28,7 @@ flysystem:
                 passive: true
                 ssl: true
                 timeout: 30
-                ignorePassiveAddress: ~
+                ignore_passive_address: ~
 ```
 
 ## SFTP

--- a/docs/B-configuration-reference.md
+++ b/docs/B-configuration-reference.md
@@ -43,7 +43,7 @@ flysystem:
                 passive: true
                 ssl: true
                 timeout: 30
-                ignorePassiveAddress: ~
+                ignore_passive_address: ~
 
         users7.storage:
             adapter: 'gcloud'

--- a/docs/B-configuration-reference.md
+++ b/docs/B-configuration-reference.md
@@ -43,6 +43,7 @@ flysystem:
                 passive: true
                 ssl: true
                 timeout: 30
+                ignorePassiveAddress: ~
 
         users7.storage:
             adapter: 'gcloud'

--- a/src/Adapter/Builder/FtpAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/FtpAdapterDefinitionBuilder.php
@@ -57,6 +57,9 @@ class FtpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
 
         $resolver->setDefault('timeout', 90);
         $resolver->setAllowedTypes('timeout', 'scalar');
+
+        $resolver->setDefault('ignorePassiveAddress', null);
+        $resolver->setAllowedTypes('ignorePassiveAddress', ['null', 'bool']);
     }
 
     protected function configureDefinition(Definition $definition, array $options)

--- a/src/Adapter/Builder/FtpAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/FtpAdapterDefinitionBuilder.php
@@ -58,12 +58,15 @@ class FtpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
         $resolver->setDefault('timeout', 90);
         $resolver->setAllowedTypes('timeout', 'scalar');
 
-        $resolver->setDefault('ignorePassiveAddress', null);
-        $resolver->setAllowedTypes('ignorePassiveAddress', ['null', 'bool']);
+        $resolver->setDefault('ignore_passive_address', null);
+        $resolver->setAllowedTypes('ignore_passive_address', ['null', 'bool']);
     }
 
     protected function configureDefinition(Definition $definition, array $options)
     {
+        $options['ignorePassiveAddress'] = $options['ignore_passive_address'];
+        unset($options['ignore_passive_address']);
+
         $definition->setClass(Ftp::class);
         $definition->setArgument(0, $options);
     }

--- a/tests/Adapter/Builder/FtpAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/FtpAdapterDefinitionBuilderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the flysystem-bundle project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\League\FlysystemBundle\Adapter\Builder;
+
+use League\Flysystem\Adapter\Ftp;
+use League\FlysystemBundle\Adapter\Builder\FtpAdapterDefinitionBuilder;
+use PHPUnit\Framework\TestCase;
+
+class FtpAdapterDefinitionBuilderTest extends TestCase
+{
+    public function createBuilder()
+    {
+        return new FtpAdapterDefinitionBuilder();
+    }
+
+    public function provideValidOptions()
+    {
+        yield 'minimal' => [[
+            'host' => 'ftp.example.com',
+            'username' => 'username',
+            'password' => 'password',
+        ]];
+
+        yield 'full' => [[
+            'host' => 'ftp.example.com',
+            'username' => 'username',
+            'password' => 'password',
+            'port' => 21,
+            'root' => '/path/to/root',
+            'passive' => true,
+            'ssl' => true,
+            'timeout' => 30,
+            'ignore_passive_address' => true,
+        ]];
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testCreateDefinition($options)
+    {
+        $this->assertSame(Ftp::class, $this->createBuilder()->createDefinition($options)->getClass());
+    }
+
+    public function testOptionsBehavior()
+    {
+        $definition = $this->createBuilder()->createDefinition([
+            'host' => 'ftp.example.com',
+            'username' => 'username',
+            'password' => 'password',
+            'port' => 21,
+            'root' => '/path/to/root',
+            'passive' => true,
+            'ssl' => true,
+            'timeout' => 30,
+            'ignore_passive_address' => true,
+        ]);
+
+        $expected = [
+            'port' => 21,
+            'root' => '/path/to/root',
+            'passive' => true,
+            'ssl' => true,
+            'timeout' => 30,
+            'host' => 'ftp.example.com',
+            'username' => 'username',
+            'password' => 'password',
+            'ignorePassiveAddress' => true,
+        ];
+
+        $this->assertSame(Ftp::class, $definition->getClass());
+        $this->assertSame($expected, $definition->getArgument(0));
+    }
+}

--- a/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the flysystem-bundle project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\League\FlysystemBundle\Adapter\Builder;
+
+use League\Flysystem\Sftp\SftpAdapter;
+use League\FlysystemBundle\Adapter\Builder\SftpAdapterDefinitionBuilder;
+use PHPUnit\Framework\TestCase;
+
+class SftpAdapterDefinitionBuilderTest extends TestCase
+{
+    public function createBuilder()
+    {
+        return new SftpAdapterDefinitionBuilder();
+    }
+
+    public function provideValidOptions()
+    {
+        yield 'minimal' => [[
+            'host' => 'ftp.example.com',
+            'username' => 'username',
+            'password' => 'password',
+        ]];
+
+        yield 'full' => [[
+            'host' => 'ftp.example.com',
+            'username' => 'username',
+            'password' => 'password',
+            'port' => 22,
+            'root' => '/path/to/root',
+            'private_key' => '/path/to/or/contents/of/privatekey',
+            'timeout' => 30,
+        ]];
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testCreateDefinition($options)
+    {
+        $this->assertSame(SftpAdapter::class, $this->createBuilder()->createDefinition($options)->getClass());
+    }
+
+    public function testOptionsBehavior()
+    {
+        $definition = $this->createBuilder()->createDefinition([
+            'host' => 'ftp.example.com',
+            'username' => 'username',
+            'password' => 'password',
+            'port' => 22,
+            'root' => '/path/to/root',
+            'private_key' => '/path/to/or/contents/of/privatekey',
+            'timeout' => 30,
+        ]);
+
+        $expected = [
+            'port' => 22,
+            'root' => '/path/to/root',
+            'private_key' => '/path/to/or/contents/of/privatekey',
+            'timeout' => 30,
+            'host' => 'ftp.example.com',
+            'username' => 'username',
+            'password' => 'password',
+        ];
+
+        $this->assertSame(SftpAdapter::class, $definition->getClass());
+        $this->assertSame($expected, $definition->getArgument(0));
+    }
+}

--- a/tests/Adapter/options.yaml
+++ b/tests/Adapter/options.yaml
@@ -35,7 +35,7 @@ fs_ftp:
         passive: true
         ssl: true
         timeout: 30
-        ignorePassiveAddress: true
+        ignore_passive_address: true
 
 fs_gcloud:
     adapter: 'gcloud'

--- a/tests/Adapter/options.yaml
+++ b/tests/Adapter/options.yaml
@@ -35,6 +35,7 @@ fs_ftp:
         passive: true
         ssl: true
         timeout: 30
+        ignorePassiveAddress: true
 
 fs_gcloud:
     adapter: 'gcloud'


### PR DESCRIPTION
In order to use FlySystem in a dockerized FTPd dev environment, I need to configure the `ignorePassiveAddress` option of the FTP Apdater. However the bundle doesn't allow us to configure this option. This PR aims to fix that.