### PR TITLE
Add missing permission options for sftp adapter

### DIFF
--- a/docs/3-interacting-with-ftp-and-sftp-servers.md
+++ b/docs/3-interacting-with-ftp-and-sftp-servers.md
@@ -57,6 +57,8 @@ flysystem:
                 root: '/path/to/root'
                 timeout: 10
                 directoryPerm: 0744
+                permPublic: 0700
+                permPrivate: 0744
 ```
 
 ## Next

--- a/docs/3-interacting-with-ftp-and-sftp-servers.md
+++ b/docs/3-interacting-with-ftp-and-sftp-servers.md
@@ -56,6 +56,7 @@ flysystem:
                 private_key: 'path/to/or/contents/of/privatekey'
                 root: '/path/to/root'
                 timeout: 10
+                directoryPerm: 0744
 ```
 
 ## Next

--- a/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
@@ -56,6 +56,17 @@ class SftpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
 
         $resolver->setDefault('timeout', 90);
         $resolver->setAllowedTypes('timeout', 'scalar');
+
+        # NOTE: Addition for SFTP Adapter configuration
+        $resolver->setDefault('directoryPerm', 0744);
+        $resolver->setAllowedTypes('directoryPerm', 'scalar');
+
+        # NOTE: Inherit configuration from AbstractFTPAdapter
+        $resolver->setDefault('permPrivate', 0700);
+        $resolver->setAllowedTypes('directoryPerm', 'scalar');
+
+        $resolver->setDefault('permPublic', 0744);
+        $resolver->setAllowedTypes('directoryPerm', 'scalar');
     }
 
     protected function configureDefinition(Definition $definition, array $options)

--- a/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
@@ -57,11 +57,9 @@ class SftpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
         $resolver->setDefault('timeout', 90);
         $resolver->setAllowedTypes('timeout', 'scalar');
 
-        # NOTE: Addition for SFTP Adapter configuration
         $resolver->setDefault('directoryPerm', 0744);
         $resolver->setAllowedTypes('directoryPerm', 'scalar');
 
-        # NOTE: Inherit configuration from AbstractFTPAdapter
         $resolver->setDefault('permPrivate', 0700);
         $resolver->setAllowedTypes('directoryPerm', 'scalar');
 

--- a/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
@@ -61,10 +61,10 @@ class SftpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
         $resolver->setAllowedTypes('directoryPerm', 'scalar');
 
         $resolver->setDefault('permPrivate', 0700);
-        $resolver->setAllowedTypes('directoryPerm', 'scalar');
+        $resolver->setAllowedTypes('permPrivate', 'scalar');
 
         $resolver->setDefault('permPublic', 0744);
-        $resolver->setAllowedTypes('directoryPerm', 'scalar');
+        $resolver->setAllowedTypes('permPublic', 'scalar');
     }
 
     protected function configureDefinition(Definition $definition, array $options)

--- a/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
@@ -59,6 +59,9 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
             'root' => '/path/to/root',
             'private_key' => '/path/to/or/contents/of/privatekey',
             'timeout' => 30,
+            'directoryPerm' => 0755,
+            'permPrivate' => 0700,
+            'permPublic' => 0744,
         ]);
 
         $expected = [
@@ -66,6 +69,9 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
             'root' => '/path/to/root',
             'private_key' => '/path/to/or/contents/of/privatekey',
             'timeout' => 30,
+            'directoryPerm' => 0755,
+            'permPrivate' => 0700,
+            'permPublic' => 0744,
             'host' => 'ftp.example.com',
             'username' => 'username',
             'password' => 'password',

--- a/tests/Kernel/config/flysystem.yaml
+++ b/tests/Kernel/config/flysystem.yaml
@@ -91,6 +91,9 @@ flysystem:
                 private_key: 'path/to/or/contents/of/privatekey'
                 root: '/path/to/root'
                 timeout: 10
+                directoryPerm: 0755
+                permPrivate: 0700
+                permPublic: 0744
 
         fs_webdav:
             adapter: 'webdav'


### PR DESCRIPTION
Fixes #17

Add `directoryPerm`, `permPrivate` and `permPublic` to configurable (for directory/file permission), also add to the sftp document