### PR TITLE
Add missing `utf8` option for ftp adapter

### DIFF
--- a/docs/3-interacting-with-ftp-and-sftp-servers.md
+++ b/docs/3-interacting-with-ftp-and-sftp-servers.md
@@ -29,6 +29,7 @@ flysystem:
                 ssl: true
                 timeout: 30
                 ignore_passive_address: ~
+                utf8: false
 ```
 
 ## SFTP

--- a/src/Adapter/Builder/FtpAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/FtpAdapterDefinitionBuilder.php
@@ -60,6 +60,9 @@ class FtpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
 
         $resolver->setDefault('ignore_passive_address', null);
         $resolver->setAllowedTypes('ignore_passive_address', ['null', 'bool']);
+
+        $resolver->setDefault('utf8', false);
+        $resolver->setAllowedTypes('utf8', 'scalar');
     }
 
     protected function configureDefinition(Definition $definition, array $options)

--- a/src/Adapter/Builder/FtpAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/FtpAdapterDefinitionBuilder.php
@@ -62,7 +62,7 @@ class FtpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
         $resolver->setAllowedTypes('ignore_passive_address', ['null', 'bool']);
 
         $resolver->setDefault('utf8', false);
-        $resolver->setAllowedTypes('utf8', 'scalar');
+        $resolver->setAllowedTypes('utf8', 'bool');
     }
 
     protected function configureDefinition(Definition $definition, array $options)

--- a/tests/Adapter/Builder/FtpAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/FtpAdapterDefinitionBuilderTest.php
@@ -40,6 +40,7 @@ class FtpAdapterDefinitionBuilderTest extends TestCase
             'ssl' => true,
             'timeout' => 30,
             'ignore_passive_address' => true,
+            'utf8' => false,
         ]];
     }
 
@@ -63,6 +64,7 @@ class FtpAdapterDefinitionBuilderTest extends TestCase
             'ssl' => true,
             'timeout' => 30,
             'ignore_passive_address' => true,
+            'utf8' => false,
         ]);
 
         $expected = [
@@ -71,6 +73,7 @@ class FtpAdapterDefinitionBuilderTest extends TestCase
             'passive' => true,
             'ssl' => true,
             'timeout' => 30,
+            'utf8' => false,
             'host' => 'ftp.example.com',
             'username' => 'username',
             'password' => 'password',

--- a/tests/Kernel/config/flysystem.yaml
+++ b/tests/Kernel/config/flysystem.yaml
@@ -40,6 +40,7 @@ flysystem:
                 passive: true
                 ssl: true
                 timeout: 30
+                utf8: false
 
         fs_gcloud:
             adapter: 'gcloud'


### PR DESCRIPTION
Adding the missing `utf8` option for the ftp adapter.