### PR TITLE
Prepend `flysystem.filesystem.` to storage service's definition id

### DIFF
--- a/src/DependencyInjection/FlysystemExtension.php
+++ b/src/DependencyInjection/FlysystemExtension.php
@@ -52,8 +52,8 @@ class FlysystemExtension extends Extension
             // Create storage service definition
             $definition = $this->createStorageDefinition(new Reference('flysystem.adapter.'.$storageName), $storageConfig);
 
-            $container->setDefinition($storageName, $definition);
-            $container->registerAliasForArgument($storageName, FilesystemInterface::class, $storageName)->setPublic(false);
+            $container->setDefinition('flysystem.filesystem.'.$storageName, $definition);
+            $container->registerAliasForArgument('flysystem.filesystem.'.$storageName, FilesystemInterface::class, $storageName)->setPublic(false);
         }
     }
 

--- a/tests/Kernel/config/services.yaml
+++ b/tests/Kernel/config/services.yaml
@@ -6,21 +6,21 @@ services:
         class: 'League\Flysystem\Adapter\NullAdapter'
 
     # Aliases used to test the services construction
-    flysystem.test.fs_aws: { alias: 'fs_aws' }
-    flysystem.test.fs_azure: { alias: 'fs_azure' }
-    flysystem.test.fs_cache: { alias: 'fs_cache' }
-    flysystem.test.fs_custom: { alias: 'fs_custom' }
-    flysystem.test.fs_dropbox: { alias: 'fs_dropbox' }
-    flysystem.test.fs_ftp: { alias: 'fs_ftp' }
-    flysystem.test.fs_gcloud: { alias: 'fs_gcloud' }
-    flysystem.test.fs_local: { alias: 'fs_local' }
-    flysystem.test.fs_memory: { alias: 'fs_memory' }
-    flysystem.test.fs_null: { alias: 'fs_null' }
-    flysystem.test.fs_rackspace: { alias: 'fs_rackspace' }
-    flysystem.test.fs_replicate: { alias: 'fs_replicate' }
-    flysystem.test.fs_sftp: { alias: 'fs_sftp' }
-    flysystem.test.fs_webdav: { alias: 'fs_webdav' }
-    flysystem.test.fs_zip: { alias: 'fs_zip' }
+    flysystem.test.fs_aws: { alias: 'flysystem.filesystem.fs_aws' }
+    flysystem.test.fs_azure: { alias: 'flysystem.filesystem.fs_azure' }
+    flysystem.test.fs_cache: { alias: 'flysystem.filesystem.fs_cache' }
+    flysystem.test.fs_custom: { alias: 'flysystem.filesystem.fs_custom' }
+    flysystem.test.fs_dropbox: { alias: 'flysystem.filesystem.fs_dropbox' }
+    flysystem.test.fs_ftp: { alias: 'flysystem.filesystem.fs_ftp' }
+    flysystem.test.fs_gcloud: { alias: 'flysystem.filesystem.fs_gcloud' }
+    flysystem.test.fs_local: { alias: 'flysystem.filesystem.fs_local' }
+    flysystem.test.fs_memory: { alias: 'flysystem.filesystem.fs_memory' }
+    flysystem.test.fs_null: { alias: 'flysystem.filesystem.fs_null' }
+    flysystem.test.fs_rackspace: { alias: 'flysystem.filesystem.fs_rackspace' }
+    flysystem.test.fs_replicate: { alias: 'flysystem.filesystem.fs_replicate' }
+    flysystem.test.fs_sftp: { alias: 'flysystem.filesystem.fs_sftp' }
+    flysystem.test.fs_webdav: { alias: 'flysystem.filesystem.fs_webdav' }
+    flysystem.test.fs_zip: { alias: 'flysystem.filesystem.fs_zip' }
 
     Tests\League\FlysystemBundle\Plugin\DummyPlugin:
         autoconfigure: true


### PR DESCRIPTION
Hello,

Within a bundle I think it's more suitable for services to be defined as `flysystem.filesystem.images.storage` instead of simply `images.storage`.

This would be a BC break just for those who would have an alias to make their services public.