### PR TITLE
SFTP adapter: fix wrong naming of privateKey option

### DIFF
--- a/docs/3-interacting-with-ftp-and-sftp-servers.md
+++ b/docs/3-interacting-with-ftp-and-sftp-servers.md
@@ -54,7 +54,7 @@ flysystem:
                 port: 22
                 username: 'username'
                 password: 'password'
-                private_key: 'path/to/or/contents/of/privatekey'
+                privateKey: 'path/to/or/contents/of/privatekey'
                 root: '/path/to/root'
                 timeout: 10
                 directoryPerm: 0744

--- a/docs/B-configuration-reference.md
+++ b/docs/B-configuration-reference.md
@@ -92,7 +92,7 @@ flysystem:
                 port: 22
                 username: 'username'
                 password: 'password'
-                private_key: 'path/to/or/contents/of/privatekey'
+                privateKey: 'path/to/or/contents/of/privatekey'
                 root: '/path/to/root'
                 timeout: 10
 

--- a/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
@@ -51,8 +51,8 @@ class SftpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
         $resolver->setDefault('root', '');
         $resolver->setAllowedTypes('root', 'string');
 
-        $resolver->setDefault('private_key', null);
-        $resolver->setAllowedTypes('private_key', ['string', 'null']);
+        $resolver->setDefault('privateKey', null);
+        $resolver->setAllowedTypes('privateKey', ['string', 'null']);
 
         $resolver->setDefault('timeout', 90);
         $resolver->setAllowedTypes('timeout', 'scalar');

--- a/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
@@ -36,7 +36,7 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
             'password' => 'password',
             'port' => 22,
             'root' => '/path/to/root',
-            'private_key' => '/path/to/or/contents/of/privatekey',
+            'privateKey' => '/path/to/or/contents/of/privatekey',
             'timeout' => 30,
         ]];
     }
@@ -57,7 +57,7 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
             'password' => 'password',
             'port' => 22,
             'root' => '/path/to/root',
-            'private_key' => '/path/to/or/contents/of/privatekey',
+            'privateKey' => '/path/to/or/contents/of/privatekey',
             'timeout' => 30,
             'directoryPerm' => 0755,
             'permPrivate' => 0700,
@@ -67,7 +67,7 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
         $expected = [
             'port' => 22,
             'root' => '/path/to/root',
-            'private_key' => '/path/to/or/contents/of/privatekey',
+            'privateKey' => '/path/to/or/contents/of/privatekey',
             'timeout' => 30,
             'directoryPerm' => 0755,
             'permPrivate' => 0700,

--- a/tests/Adapter/options.yaml
+++ b/tests/Adapter/options.yaml
@@ -84,7 +84,7 @@ fs_sftp:
         port: 22
         username: 'username'
         password: 'password'
-        private_key: 'path/to/or/contents/of/privatekey'
+        privateKey: 'path/to/or/contents/of/privatekey'
         root: '/path/to/root'
         timeout: 10
 

--- a/tests/Kernel/config/flysystem.yaml
+++ b/tests/Kernel/config/flysystem.yaml
@@ -89,7 +89,7 @@ flysystem:
                 port: 22
                 username: 'username'
                 password: 'password'
-                private_key: 'path/to/or/contents/of/privatekey'
+                privateKey: 'path/to/or/contents/of/privatekey'
                 root: '/path/to/root'
                 timeout: 10
                 directoryPerm: 0755


### PR DESCRIPTION
Changed the naming of the privateKey option according to the SFTP adapter documentation: https://flysystem.thephpleague.com/docs/adapter/sftp/