### PR TITLE
remove unused BC layer for Symfony 4.1

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('flysystem');
-        $rootNode = $this->getRootNode($treeBuilder, 'flysystem');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->fixXmlConfig('storage')
@@ -51,15 +51,5 @@ class Configuration implements ConfigurationInterface
         ;
 
         return $treeBuilder;
-    }
-
-    private function getRootNode(TreeBuilder $treeBuilder, $name)
-    {
-        // BC layer for symfony/config 4.1 and older
-        if (!\method_exists($treeBuilder, 'getRootNode')) {
-            return $treeBuilder->root($name);
-        }
-
-        return $treeBuilder->getRootNode();
     }
 }


### PR DESCRIPTION
I noticed that you still have the BC layer for the tree builders root node for Symfony <= 4.1 in the bundle Configuration.

I think this piece of code can be removed, as both your README and composer.json state that Symfony 4.2+ is required and `getRootNode()` definitely [exists in SF4.2](https://github.com/symfony/symfony/blob/4.2/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php#L57).

What do you think @tgalopin ?