### PR TITLE
Resolve environment placeholders

### DIFF
--- a/src/DependencyInjection/FlysystemExtension.php
+++ b/src/DependencyInjection/FlysystemExtension.php
@@ -33,6 +33,7 @@ class FlysystemExtension extends Extension
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
+        $container->resolveEnvPlaceholders($config);
 
         $container
             ->registerForAutoconfiguration(PluginInterface::class)


### PR DESCRIPTION
When using environment variables as values for config parameters that are read conditionally, symfony can mark that environment variable as unused and throw a fatal error.

Following https://github.com/thephpleague/flysystem-bundle/blob/master/docs/5-using-lazy-adapter-to-switch-at-runtime.md, I got `Environment variables "APP_UPLOADS_SOURCE" are never used. Please, check your container's configuration.  
`

See https://github.com/php-translation/symfony-bundle/pull/379 and https://github.com/symfony/symfony/issues/23520#issuecomment-336167214