### PR TITLE
Add support for AsyncAws

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_script:
     - composer self-update
     - composer require --no-update symfony/config=$SYMFONY_VERSION symfony/http-kernel=$SYMFONY_VERSION symfony/dependency-injection=$SYMFONY_VERSION symfony/options-resolver=$SYMFONY_VERSION
     - composer require --no-update --dev symfony/framework-bundle=$SYMFONY_VERSION symfony/yaml=$SYMFONY_VERSION
+    - if [[ $TRAVIS_PHP_VERSION == "7.1" ]]; then composer remove async-aws/flysystem-s3 --dev --no-update; fi
     - composer update $COMPOSER_FLAGS --prefer-dist
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/options-resolver": "^4.2|^5.0"
     },
     "require-dev": {
-        "async-aws/flysystem-s3": "^0.3",
+        "async-aws/flysystem-s3": "^0.4",
         "league/flysystem-aws-s3-v3": "^1.0.22",
         "league/flysystem-azure-blob-storage": "^0.1.5",
         "league/flysystem-cached-adapter": "^1.0.9",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "symfony/options-resolver": "^4.2|^5.0"
     },
     "require-dev": {
+        "async-aws/flysystem-s3": "^0.3",
         "league/flysystem-aws-s3-v3": "^1.0.22",
         "league/flysystem-azure-blob-storage": "^0.1.5",
         "league/flysystem-cached-adapter": "^1.0.9",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/options-resolver": "^4.2|^5.0"
     },
     "require-dev": {
-        "async-aws/flysystem-s3": "^0.4",
+        "async-aws/flysystem-s3": "^0.3",
         "league/flysystem-aws-s3-v3": "^1.0.22",
         "league/flysystem-azure-blob-storage": "^0.1.5",
         "league/flysystem-cached-adapter": "^1.0.9",

--- a/src/Adapter/AdapterDefinitionFactory.php
+++ b/src/Adapter/AdapterDefinitionFactory.php
@@ -29,6 +29,7 @@ class AdapterDefinitionFactory
     public function __construct()
     {
         $this->builders = [
+            new Builder\AsyncAwsAdapterDefinitionBuilder(),
             new Builder\AwsAdapterDefinitionBuilder(),
             new Builder\AzureAdapterDefinitionBuilder(),
             new Builder\CacheAdapterDefinitionBuilder(),

--- a/src/Adapter/Builder/AsyncAwsAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/AsyncAwsAdapterDefinitionBuilder.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the flysystem-bundle project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\FlysystemBundle\Adapter\Builder;
+
+use AsyncAws\Flysystem\S3\S3FilesystemV1;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * @internal
+ */
+class AsyncAwsAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
+{
+    public function getName(): string
+    {
+        return 'asyncaws';
+    }
+
+    protected function getRequiredPackages(): array
+    {
+        return [
+            S3FilesystemV1::class => 'async-aws/flysystem-s3',
+        ];
+    }
+
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setRequired('client');
+        $resolver->setAllowedTypes('client', 'string');
+
+        $resolver->setRequired('bucket');
+        $resolver->setAllowedTypes('bucket', 'string');
+
+        $resolver->setDefault('prefix', '');
+        $resolver->setAllowedTypes('prefix', 'string');
+
+        $resolver->setDefault('options', []);
+        $resolver->setAllowedTypes('options', 'array');
+    }
+
+    protected function configureDefinition(Definition $definition, array $options)
+    {
+        $definition->setClass(S3FilesystemV1::class);
+        $definition->setArgument(0, new Reference($options['client']));
+        $definition->setArgument(1, $options['bucket']);
+        $definition->setArgument(2, $options['prefix']);
+        $definition->setArgument(3, $options['options']);
+    }
+}

--- a/tests/Adapter/AdapterDefinitionFactoryTest.php
+++ b/tests/Adapter/AdapterDefinitionFactoryTest.php
@@ -23,6 +23,9 @@ class AdapterDefinitionFactoryTest extends TestCase
         $config = Yaml::parseFile(__DIR__.'/options.yaml');
 
         foreach ($config as $fs) {
+            if (isset($fs['_php_version']) && version_compare(PHP_VERSION, $fs['_php_version'], '<')) {
+                continue;
+            }
             yield $fs['adapter'] => [$fs['adapter'], $fs['options'] ?? []];
         }
     }

--- a/tests/Adapter/Builder/AsyncAwsAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/AsyncAwsAdapterDefinitionBuilderTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the flysystem-bundle project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\League\FlysystemBundle\Adapter\Builder;
+
+use AsyncAws\Flysystem\S3\S3FilesystemV1;
+use League\FlysystemBundle\Adapter\Builder\AsyncAwsAdapterDefinitionBuilder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @requires PHP 7.2
+ */
+class AsyncAwsAdapterDefinitionBuilderTest extends TestCase
+{
+    public function createBuilder()
+    {
+        return new AsyncAwsAdapterDefinitionBuilder();
+    }
+
+    public function provideValidOptions()
+    {
+        yield 'minimal' => [[
+            'client' => 'my_client',
+            'bucket' => 'bucket',
+        ]];
+
+        yield 'prefix' => [[
+            'client' => 'my_client',
+            'bucket' => 'bucket',
+            'prefix' => 'prefix/path',
+        ]];
+
+        yield 'options' => [[
+            'client' => 'my_client',
+            'bucket' => 'bucket',
+            'options' => [
+                'ServerSideEncryption' => 'AES256',
+            ],
+        ]];
+    }
+
+    /**
+     * @dataProvider provideValidOptions
+     */
+    public function testCreateDefinition($options)
+    {
+        $this->assertSame(S3FilesystemV1::class, $this->createBuilder()->createDefinition($options)->getClass());
+    }
+
+    public function testOptionsBehavior()
+    {
+        $definition = $this->createBuilder()->createDefinition([
+            'client' => 'my_client',
+            'bucket' => 'bucket',
+            'prefix' => 'prefix/path',
+            'options' => [
+                'ServerSideEncryption' => 'AES256',
+            ],
+        ]);
+
+        $this->assertSame(S3FilesystemV1::class, $definition->getClass());
+        $this->assertInstanceOf(Reference::class, $definition->getArgument(0));
+        $this->assertSame('my_client', (string) $definition->getArgument(0));
+        $this->assertSame('bucket', $definition->getArgument(1));
+        $this->assertSame('prefix/path', $definition->getArgument(2));
+        $this->assertSame(['ServerSideEncryption' => 'AES256'], $definition->getArgument(3));
+    }
+}

--- a/tests/Adapter/options.yaml
+++ b/tests/Adapter/options.yaml
@@ -1,3 +1,11 @@
+fs_async_aws:
+    _php_version: '7.2.5'
+    adapter: 'asyncaws'
+    options:
+        client: 'aws_client_service'
+        bucket: 'bucket_name'
+        prefix: 'optional/path/prefix'
+
 fs_aws:
     adapter: 'aws'
     options:


### PR DESCRIPTION
The [Async Aws](https://github.com/async-aws/aws) is basically the same thing as the official AWS PHP SDK but with a few differences: 

- Async first
- No Guzzle, Yes Symfony HTTP Client
- Readable code
- Small package size
