### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,5 +121,5 @@ This library follows the same Backward Compatibility promise as the Symfony fram
 [https://symfony.com/doc/current/contributing/code/bc.html](https://symfony.com/doc/current/contributing/code/bc.html)
 
 > *Note*: many classes in this bundle are either marked `@final` or `@internal`.
-> `@internal` classes are excluded from any Backward Compatiblity promise (you should not use them in your code)
+> `@internal` classes are excluded from any Backward Compatibility promise (you should not use them in your code)
 > whereas `@final` classes can be used but should not be extended (use composition instead).

--- a/docs/4-caching-metadata-in-symfony-cache.md
+++ b/docs/4-caching-metadata-in-symfony-cache.md
@@ -27,7 +27,7 @@ and a [Symfony cache pool](https://symfony.com/doc/current/reference/configurati
 Most of the time you are only going to need one of two possibilities:
 
 * in-memory cache (will expire at the end of the CLI process or HTTP request) ;
-* persistant cache (will stay persistent in a cache backend) ;
+* persistent cache (will stay persistent in a cache backend) ;
 
 #### Memory caching
 

--- a/docs/6-creating-a-custom-adapter.md
+++ b/docs/6-creating-a-custom-adapter.md
@@ -8,7 +8,7 @@ and then use it in your storages configuration.
 
 ## Creating the adapter class
 
-A Flysystem adapter is a class implementing the `League\Flysystem\AdapterInterface` inteface.
+A Flysystem adapter is a class implementing the `League\Flysystem\AdapterInterface` interface.
 To learn all the details about how to create this class, you can read the 
 [library documentation](https://flysystem.thephpleague.com/docs/advanced/creating-an-adapter/).
 


### PR DESCRIPTION
Hello,

This PR will fix : 

- 1 typo in `README.md`
- 1 typo in `docs/4-caching-metadata-in-symfony-cache.md`
- 1 typo in `docs/6-creating-a-custom-adapter.md`



Cheers! :robot: