### PR TITLE
Fix non-string env vars handling in FtpAdapterDefinitionBuilder

### DIFF
--- a/src/Adapter/Builder/FtpAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/FtpAdapterDefinitionBuilder.php
@@ -59,10 +59,10 @@ class FtpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
         $resolver->setAllowedTypes('timeout', 'scalar');
 
         $resolver->setDefault('ignore_passive_address', null);
-        $resolver->setAllowedTypes('ignore_passive_address', ['null', 'bool']);
+        $resolver->setAllowedTypes('ignore_passive_address', ['null', 'bool', 'scalar']);
 
         $resolver->setDefault('utf8', false);
-        $resolver->setAllowedTypes('utf8', 'bool');
+        $resolver->setAllowedTypes('utf8', 'scalar');
     }
 
     protected function configureDefinition(Definition $definition, array $options)


### PR DESCRIPTION
In a private project we faced the exact same issue for FTP options as were in #7 so I created this PR according to it's fix in #8 .