### PR TITLE
Automatically configure a MountManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ to interact with your storage.
 4. [Caching metadata in Symfony cache](https://github.com/thephpleague/flysystem-bundle/blob/master/docs/4-caching-metadata-in-symfony-cache.md)
 5. [Using a lazy adapter to switch storage backend using an environment variable](https://github.com/thephpleague/flysystem-bundle/blob/master/docs/5-using-lazy-adapter-to-switch-at-runtime.md)
 6. [Creating a custom adapter](https://github.com/thephpleague/flysystem-bundle/blob/master/docs/6-creating-a-custom-adapter.md)
+7. [Using the Mount Manager](https://github.com/thephpleague/flysystem-bundle/blob/master/docs/7-using-the-mount-manager.md)
 
 * [Security issue disclosure procedure](https://github.com/thephpleague/flysystem-bundle/blob/master/docs/A-security-disclosure-procedure.md)
 * [Configuration reference](https://github.com/thephpleague/flysystem-bundle/blob/master/docs/B-configuration-reference.md)

--- a/docs/7-using-the-mount-manager.md
+++ b/docs/7-using-the-mount-manager.md
@@ -1,0 +1,55 @@
+# Using the Mount Manager a custom adapter
+
+[Read the associated library documentation](https://flysystem.thephpleague.com/v1/docs/advanced/mount-manager/)
+
+If you're using multiple filesystems in an application it can be convenient to leverage Flysystem's
+[`MountManager`](https://flysystem.thephpleague.com/v1/docs/advanced/mount-manager/) to access different filesystems
+from a single object.
+
+## Configuring mount prefixes
+
+Each filesystem you want to include in the `MountManager` must be configured with a `mount_prefix` option:
+
+```yaml
+# config/packages/flysystem.yaml
+
+flysystem:
+    storages:
+        default.storage:
+            adapter: 'local'
+            options:
+                directory: '%kernel.project_dir%/var/storage/default'
+            mount_prefix: 'local'
+        s3.storage:
+            adapter: 'aws'
+            options:
+                client: 'aws_client_service' # The service ID of the Aws\S3\S3Client instance
+                bucket: 'bucket_name'
+                prefix: 'optional/path/prefix'
+          mount_prefix: 's3'
+```
+
+(This option is only required if you intend to use this feature.)
+
+## Injecting the Mount Manager
+
+You can then inject the `flysystem.mount_manager` service (or reference the `MountManager` class with autowiring) in your classes to access the `MountManager` and work with your multiple filesystems:
+
+```php
+use League\Flysystem\MountManager;
+
+class MyController
+{
+    public function index(MountManager $manager)
+    {
+        // Read from local storage
+        $contents = $manager->read('local://some/file.txt');
+
+        // And write to an S3 bucket
+        $manager->write('s3://put/it/here.txt', $contents);
+
+        // Or better yet, use the specialized "copy" call
+        $manager->copy('local://some/file.ext', 's3://put/it/here.txt');
+    }
+}
+```

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -43,6 +43,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('visibility')->defaultNull()->end()
                             ->booleanNode('case_sensitive')->defaultTrue()->end()
                             ->booleanNode('disable_asserts')->defaultFalse()->end()
+                            ->scalarNode('mount_prefix')->defaultNull()->end()
                         ->end()
                     ->end()
                     ->defaultValue([])

--- a/tests/Fakes/FakeMountManagerUser.php
+++ b/tests/Fakes/FakeMountManagerUser.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\League\FlysystemBundle\Fakes;
+
+use League\Flysystem\MountManager;
+
+final class FakeMountManagerUser
+{
+    /** @var MountManager */
+    private $mountManager;
+
+    public function __construct(MountManager $mountManager)
+    {
+        $this->mountManager = $mountManager;
+    }
+
+    public function getMountManager(): MountManager
+    {
+        return $this->mountManager;
+    }
+}

--- a/tests/Kernel/config/flysystem.yaml
+++ b/tests/Kernel/config/flysystem.yaml
@@ -13,6 +13,7 @@ flysystem:
                 client: 'aws_client_service'
                 bucket: '%env(AWS_BUCKET)%'
                 prefix: 'optional/path/prefix'
+            mount_prefix: 's3'
 
         fs_azure:
             adapter: 'azure'
@@ -75,9 +76,11 @@ flysystem:
                     dir:
                         public: 0755
                         private: 0700
+            mount_prefix: 'local'
 
         fs_memory:
             adapter: 'memory'
+            mount_prefix: 'memory'
 
         fs_null:
             adapter: 'null'

--- a/tests/Kernel/config/services.yaml
+++ b/tests/Kernel/config/services.yaml
@@ -23,6 +23,10 @@ services:
     flysystem.test.fs_sftp: { alias: 'fs_sftp' }
     flysystem.test.fs_webdav: { alias: 'fs_webdav' }
     flysystem.test.fs_zip: { alias: 'fs_zip' }
+    flysystem.test.mount_manager: { alias: 'flysystem.mount_manager' }
 
     Tests\League\FlysystemBundle\Plugin\DummyPlugin:
         autoconfigure: true
+
+    Tests\League\FlysystemBundle\Fakes\FakeMountManagerUser:
+        autowire: true


### PR DESCRIPTION
The `MountManager` greatly simplifies the ability to work with multiple filesystems.  Currently, I'd have to set this object up myself in Symfony's DI container.  It would be great if this bundle could do that for me.  This PR adds that functionality.

By default, no filesystems are registered because we don't know what prefix the developer may want to use.  I considered using the service alias, but that would result in strange-looking "URLs".  I've therefore implemented this functionality as opt-in.