### PR TITLE
Add comment in aws adapter example to show how to set visibility

### DIFF
--- a/docs/2-cloud-storage-providers.md
+++ b/docs/2-cloud-storage-providers.md
@@ -76,6 +76,7 @@ flysystem:
     storages:
         users.storage:
             adapter: 'aws'
+            # visibility: public # Make the uploaded file publicly accessible in S3
             options:
                 client: 'aws_client_service' # The service ID of the Aws\S3\S3Client instance
                 bucket: 'bucket_name'


### PR DESCRIPTION
This PR adds a comment to the aws adapter example to show how to set the visibility to public for uploaded files. I found this config option by looking through issues. I didn't notice it anywhere else.