### PR TITLE
Rename S3FilesystemV1 to AsyncAwsS3Adapter (missed in last release)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     },
     "conflict": {
         "league/flysystem-aws-s3-v3": "<1.0.22",
+        "async-aws/flysystem-s3": "<1.0",
         "league/flysystem-cached-adapter": "<1.0.9"
     },
     "config": {

--- a/src/Adapter/Builder/AsyncAwsAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/AsyncAwsAdapterDefinitionBuilder.php
@@ -11,7 +11,7 @@
 
 namespace League\FlysystemBundle\Adapter\Builder;
 
-use AsyncAws\Flysystem\S3\S3FilesystemV1;
+use AsyncAws\Flysystem\S3\AsyncAwsS3Adapter;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -32,7 +32,7 @@ class AsyncAwsAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
     protected function getRequiredPackages(): array
     {
         return [
-            S3FilesystemV1::class => 'async-aws/flysystem-s3',
+            AsyncAwsS3Adapter::class => 'async-aws/flysystem-s3',
         ];
     }
 
@@ -53,7 +53,7 @@ class AsyncAwsAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
 
     protected function configureDefinition(Definition $definition, array $options)
     {
-        $definition->setClass(S3FilesystemV1::class);
+        $definition->setClass(AsyncAwsS3Adapter::class);
         $definition->setArgument(0, new Reference($options['client']));
         $definition->setArgument(1, $options['bucket']);
         $definition->setArgument(2, $options['prefix']);

--- a/tests/Adapter/Builder/AsyncAwsAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/AsyncAwsAdapterDefinitionBuilderTest.php
@@ -11,7 +11,7 @@
 
 namespace Tests\League\FlysystemBundle\Adapter\Builder;
 
-use AsyncAws\Flysystem\S3\S3FilesystemV1;
+use AsyncAws\Flysystem\S3\AsyncAwsS3Adapter;
 use League\FlysystemBundle\Adapter\Builder\AsyncAwsAdapterDefinitionBuilder;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Reference;
@@ -53,7 +53,7 @@ class AsyncAwsAdapterDefinitionBuilderTest extends TestCase
      */
     public function testCreateDefinition($options)
     {
-        $this->assertSame(S3FilesystemV1::class, $this->createBuilder()->createDefinition($options)->getClass());
+        $this->assertSame(AsyncAwsS3Adapter::class, $this->createBuilder()->createDefinition($options)->getClass());
     }
 
     public function testOptionsBehavior()
@@ -67,7 +67,7 @@ class AsyncAwsAdapterDefinitionBuilderTest extends TestCase
             ],
         ]);
 
-        $this->assertSame(S3FilesystemV1::class, $definition->getClass());
+        $this->assertSame(AsyncAwsS3Adapter::class, $definition->getClass());
         $this->assertInstanceOf(Reference::class, $definition->getArgument(0));
         $this->assertSame('my_client', (string) $definition->getArgument(0));
         $this->assertSame('bucket', $definition->getArgument(1));


### PR DESCRIPTION
rename missed renaming in the last release `1.0.0` from  `S3FilesystemV1` to `AsyncAwsS3Adapter`