### PR TITLE
Add directory_visibility config

### DIFF
--- a/docs/B-configuration-reference.md
+++ b/docs/B-configuration-reference.md
@@ -63,4 +63,10 @@ flysystem:
                 privateKey: 'path/to/or/contents/of/privatekey'
                 root: '/path/to/root'
                 timeout: 10
+
+        users9.storage:
+            adapter: 'lazy'
+            options:
+                source: 'flysystem_storage_service_to_use'
+
 ```

--- a/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
@@ -43,8 +43,8 @@ class SftpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
         $resolver->setRequired('username');
         $resolver->setAllowedTypes('username', 'string');
 
-        $resolver->setRequired('password');
-        $resolver->setAllowedTypes('password', 'string');
+        $resolver->setDefault('password', null);
+        $resolver->setAllowedTypes('password', ['string', 'null']);
 
         $resolver->setDefault('port', 22);
         $resolver->setAllowedTypes('port', 'scalar');

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue([])
                             ->end()
                             ->scalarNode('visibility')->defaultNull()->end()
+                            ->scalarNode('directory_visibility')->defaultNull()->end()
                             ->booleanNode('case_sensitive')->defaultTrue()->end()
                             ->booleanNode('disable_asserts')->defaultFalse()->end()
                         ->end()

--- a/src/DependencyInjection/FlysystemExtension.php
+++ b/src/DependencyInjection/FlysystemExtension.php
@@ -105,6 +105,7 @@ class FlysystemExtension extends Extension
         $definition->setArgument(0, $adapter);
         $definition->setArgument(1, [
             'visibility' => $config['visibility'],
+            'directory_visibility' => $config['directory_visibility'],
             'case_sensitive' => $config['case_sensitive'],
             'disable_asserts' => $config['disable_asserts'],
         ]);

--- a/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
@@ -27,7 +27,6 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
         yield 'minimal' => [[
             'host' => 'ftp.example.com',
             'username' => 'username',
-            'password' => 'password',
         ]];
 
         yield 'full' => [[
@@ -65,6 +64,7 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
         ]);
 
         $expected = [
+            'password' => 'password',
             'port' => 22,
             'root' => '/path/to/root',
             'privateKey' => '/path/to/or/contents/of/privatekey',
@@ -74,7 +74,6 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
             'permPublic' => 0744,
             'host' => 'ftp.example.com',
             'username' => 'username',
-            'password' => 'password',
         ];
 
         $this->assertSame(SftpAdapter::class, $definition->getClass());

--- a/tests/Kernel/config/flysystem.yaml
+++ b/tests/Kernel/config/flysystem.yaml
@@ -56,6 +56,20 @@ flysystem:
                         public: 0755
                         private: 0700
 
+        fs_local_private:
+            adapter: 'local'
+            options:
+                directory: '/tmp/storage'
+            visibility: private
+            directory_visibility: private
+
+        fs_local_public:
+            adapter: 'local'
+            options:
+                directory: '/tmp/storage'
+            visibility: public
+            directory_visibility: public
+
         fs_memory:
             adapter: 'memory'
 

--- a/tests/Kernel/config/services.yaml
+++ b/tests/Kernel/config/services.yaml
@@ -15,3 +15,6 @@ services:
     flysystem.test.fs_local: { alias: 'fs_local' }
     flysystem.test.fs_memory: { alias: 'fs_memory' }
     flysystem.test.fs_sftp: { alias: 'fs_sftp' }
+
+    flysystem.test.fs_local_private: { alias: 'fs_local_private' }
+    flysystem.test.fs_local_public: { alias: 'fs_local_public' }


### PR DESCRIPTION
Adapters are using `$config->get(Config::OPTION_DIRECTORY_VISIBILITY)` but currently isn't configurable from the bundle. This PR indents to fix that.