### PR TITLE
Fix permissions for SftpAdapter

### DIFF
--- a/docs/3-interacting-with-ftp-and-sftp-servers.md
+++ b/docs/3-interacting-with-ftp-and-sftp-servers.md
@@ -59,9 +59,13 @@ flysystem:
                 privateKey: 'path/to/or/contents/of/privatekey'
                 root: '/path/to/root'
                 timeout: 10
-                directoryPerm: 0744
-                permPublic: 0700
-                permPrivate: 0744
+                permissions:
+                  file:
+                    public: 0744
+                    private: 0700
+                  dir:
+                    public: 0755
+                    private: 0700
 ```
 
 ## Next

--- a/docs/B-configuration-reference.md
+++ b/docs/B-configuration-reference.md
@@ -63,4 +63,11 @@ flysystem:
                 privateKey: 'path/to/or/contents/of/privatekey'
                 root: '/path/to/root'
                 timeout: 10
+                permissions:
+                  file:
+                    public: 0744
+                    private: 0700
+                  dir:
+                    public: 0755
+                    private: 0700
 ```

--- a/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
@@ -13,6 +13,7 @@ namespace League\FlysystemBundle\Adapter\Builder;
 
 use League\Flysystem\PhpseclibV2\SftpAdapter;
 use League\Flysystem\PhpseclibV2\SftpConnectionProvider;
+use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -58,13 +59,34 @@ class SftpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
         $resolver->setDefault('timeout', 90);
         $resolver->setAllowedTypes('timeout', 'scalar');
 
+        $resolver->setDefault('permissions', function (OptionsResolver $subResolver) {
+            $subResolver->setDefault('file', function (OptionsResolver $permsResolver) {
+                $permsResolver->setDefault('public', 0644);
+                $permsResolver->setAllowedTypes('public', 'scalar');
+
+                $permsResolver->setDefault('private', 0600);
+                $permsResolver->setAllowedTypes('private', 'scalar');
+            });
+
+            $subResolver->setDefault('dir', function (OptionsResolver $permsResolver) {
+                $permsResolver->setDefault('public', 0755);
+                $permsResolver->setAllowedTypes('public', 'scalar');
+
+                $permsResolver->setDefault('private', 0700);
+                $permsResolver->setAllowedTypes('private', 'scalar');
+            });
+        });
+
         $resolver->setDefault('directoryPerm', 0744);
+        $resolver->setDeprecated('directoryPerm', 'league/flysystem-bundle', '2.0.1', 'The option "directoryPerm" is deprecated, use "permissions.dir.public" and "permissions.dir.private" instead.');
         $resolver->setAllowedTypes('directoryPerm', 'scalar');
 
         $resolver->setDefault('permPrivate', 0700);
+        $resolver->setDeprecated('permPrivate', 'league/flysystem-bundle', '2.0.1', 'The option "permPrivate" is deprecated, use "permissions.file.private" instead.');
         $resolver->setAllowedTypes('permPrivate', 'scalar');
 
         $resolver->setDefault('permPublic', 0744);
+        $resolver->setDeprecated('permPublic', 'league/flysystem-bundle', '2.0.1', 'The option "permPublic" is deprecated, use "permissions.file.public" instead.');
         $resolver->setAllowedTypes('permPublic', 'scalar');
     }
 
@@ -78,5 +100,11 @@ class SftpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
                 ->setShared(false)
         );
         $definition->setArgument(1, $options['root']);
+        $definition->setArgument(2,
+            (new Definition(PortableVisibilityConverter::class))
+                ->setFactory([PortableVisibilityConverter::class, 'fromArray'])
+                ->addArgument($options['permissions'])
+                ->setShared(false)
+        );
     }
 }

--- a/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
@@ -51,6 +51,17 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
 
     public function testOptionsBehavior()
     {
+        $permissions = [
+            'file' => [
+                'public' => 0755,
+                'private' => 0755,
+            ],
+            'dir' => [
+                'public' => 0755,
+                'private' => 0755,
+            ],
+        ];
+
         $definition = $this->createBuilder()->createDefinition([
             'host' => 'ftp.example.com',
             'username' => 'username',
@@ -59,9 +70,7 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
             'root' => '/path/to/root',
             'privateKey' => '/path/to/or/contents/of/privatekey',
             'timeout' => 30,
-            'directoryPerm' => 0755,
-            'permPrivate' => 0700,
-            'permPublic' => 0744,
+            'permissions' => $permissions,
         ]);
 
         $expected = [
@@ -69,7 +78,8 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
             'root' => '/path/to/root',
             'privateKey' => '/path/to/or/contents/of/privatekey',
             'timeout' => 30,
-            'directoryPerm' => 0755,
+            'permissions' => $permissions,
+            'directoryPerm' => 0744,
             'permPrivate' => 0700,
             'permPublic' => 0744,
             'host' => 'ftp.example.com',
@@ -80,5 +90,6 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
         $this->assertSame(SftpAdapter::class, $definition->getClass());
         $this->assertSame($expected, $definition->getArgument(0)->getArgument(0));
         $this->assertSame($expected['root'], $definition->getArgument(1));
+        $this->assertSame($permissions, $definition->getArgument(2)->getArgument(0));
     }
 }

--- a/tests/Kernel/config/flysystem.yaml
+++ b/tests/Kernel/config/flysystem.yaml
@@ -50,11 +50,11 @@ flysystem:
                 skip_links: false
                 permissions:
                     file:
-                        public: 0744
-                        private: 0700
+                        public: 0o744
+                        private: 0o700
                     dir:
-                        public: 0755
-                        private: 0700
+                        public: 0o755
+                        private: 0o700
 
         fs_memory:
             adapter: 'memory'
@@ -69,6 +69,10 @@ flysystem:
                 privateKey: 'path/to/or/contents/of/privatekey'
                 root: '/path/to/root'
                 timeout: 10
-                directoryPerm: 0755
-                permPrivate: 0700
-                permPublic: 0744
+                permissions:
+                    file:
+                        public: 0o744
+                        private: 0o700
+                    dir:
+                        public: 0o755
+                        private: 0o700


### PR DESCRIPTION
SftpAdapter currently doesn't make use of `directoryPerm`, `permPublic` or `permPrivate`. 

This PR changes to a similar structure as `LocalAdapter` by using `permissions` and deprecate the old configuration values.

I'm open to suggestions regarding the deprecations.