### PR TITLE
Allow null password for SFTP

### DIFF
--- a/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
@@ -43,8 +43,8 @@ class SftpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
         $resolver->setRequired('username');
         $resolver->setAllowedTypes('username', 'string');
 
-        $resolver->setRequired('password');
-        $resolver->setAllowedTypes('password', 'string');
+        $resolver->setDefault('password', null);
+        $resolver->setAllowedTypes('password', ['string', 'null']);
 
         $resolver->setDefault('port', 22);
         $resolver->setAllowedTypes('port', 'scalar');

--- a/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
@@ -27,7 +27,6 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
         yield 'minimal' => [[
             'host' => 'ftp.example.com',
             'username' => 'username',
-            'password' => 'password',
         ]];
 
         yield 'full' => [[
@@ -65,6 +64,7 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
         ]);
 
         $expected = [
+            'password' => 'password',
             'port' => 22,
             'root' => '/path/to/root',
             'privateKey' => '/path/to/or/contents/of/privatekey',
@@ -74,7 +74,6 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
             'permPublic' => 0744,
             'host' => 'ftp.example.com',
             'username' => 'username',
-            'password' => 'password',
         ];
 
         $this->assertSame(SftpAdapter::class, $definition->getClass());


### PR DESCRIPTION
Hi @tgalopin 

A null pasword is allowed by flysystem-stfp.

See https://github.com/thephpleague/flysystem-sftp/blob/2.x/SftpConnectionProvider.php#L25