### PR TITLE
fix(docs): File permission should be octal in yaml

### DIFF
--- a/docs/B-configuration-reference.md
+++ b/docs/B-configuration-reference.md
@@ -41,11 +41,11 @@ flysystem:
                 skip_links: false
                 permissions:
                     file:
-                        public: 0744
-                        private: 0700
+                        public: 0o744
+                        private: 0o700
                     dir:
-                        public: 0755
-                        private: 0700
+                        public: 0o755
+                        private: 0o700
             visibility: ~ # default null. Possible values are 'public' or 'private'
             case_sensitive: true
             disable_asserts: false


### PR DESCRIPTION
Without the octal type this results in very weird file permissions