### PR TITLE
fix: missing directory_visibility configuration option

### DIFF
--- a/docs/B-configuration-reference.md
+++ b/docs/B-configuration-reference.md
@@ -47,7 +47,7 @@ flysystem:
                         public: 0755
                         private: 0700
             visibility: ~ # default null. Possible values are 'public' or 'private'
-            directoy_visibility: ~ # default null. Possible values are 'public' or 'private'
+            directory_visibility: ~ # default null. Possible values are 'public' or 'private'
             case_sensitive: true
             disable_asserts: false
 

--- a/docs/B-configuration-reference.md
+++ b/docs/B-configuration-reference.md
@@ -47,6 +47,7 @@ flysystem:
                         public: 0755
                         private: 0700
             visibility: ~ # default null. Possible values are 'public' or 'private'
+            directoy_visibility: ~ # default null. Possible values are 'public' or 'private'
             case_sensitive: true
             disable_asserts: false
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue([])
                             ->end()
                             ->scalarNode('visibility')->defaultNull()->end()
+                            ->scalarNode('directory_visibility')->defaultNull()->end()
                             ->booleanNode('case_sensitive')->defaultTrue()->end()
                             ->booleanNode('disable_asserts')->defaultFalse()->end()
                         ->end()

--- a/src/DependencyInjection/FlysystemExtension.php
+++ b/src/DependencyInjection/FlysystemExtension.php
@@ -105,6 +105,7 @@ class FlysystemExtension extends Extension
         $definition->setArgument(0, $adapter);
         $definition->setArgument(1, [
             'visibility' => $config['visibility'],
+            'directory_visibility' => $config['directory_visibility'],
             'case_sensitive' => $config['case_sensitive'],
             'disable_asserts' => $config['disable_asserts'],
         ]);


### PR DESCRIPTION
Fixes #93 

This option as been added some time ago in V3 and without it, directories will ALWAYS be created with private permissions even with `visibility: public`

https://github.com/thephpleague/flysystem/blob/3.x/src/Config.php#L12