### PR TITLE
Fix sftp permission

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -41,6 +41,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue([])
                             ->end()
                             ->scalarNode('visibility')->defaultNull()->end()
+                            ->scalarNode('directory_visibility')->defaultNull()->end()
                             ->booleanNode('case_sensitive')->defaultTrue()->end()
                             ->booleanNode('disable_asserts')->defaultFalse()->end()
                         ->end()

--- a/src/DependencyInjection/FlysystemExtension.php
+++ b/src/DependencyInjection/FlysystemExtension.php
@@ -105,6 +105,7 @@ class FlysystemExtension extends Extension
         $definition->setArgument(0, $adapter);
         $definition->setArgument(1, [
             'visibility' => $config['visibility'],
+            'directory_visibility' => $config['directory_visibility'],
             'case_sensitive' => $config['case_sensitive'],
             'disable_asserts' => $config['disable_asserts'],
         ]);


### PR DESCRIPTION
This PR will fix #113 . A new configuration node was added in order to allow `directory_visibility` to be set

```yaml
        asset_remote.storage:
            adapter: 'sftp'
            visibility: 'public'
            directory_visibility: 'public'
// omitted
```