### PR TITLE
Add type declaration to avoid warnings

### DIFF
--- a/src/DependencyInjection/Compiler/LazyFactoryPass.php
+++ b/src/DependencyInjection/Compiler/LazyFactoryPass.php
@@ -26,7 +26,7 @@ class LazyFactoryPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $factories = [];
         foreach ($container->findTaggedServiceIds('flysystem.storage') as $serviceId => $tags) {

--- a/src/DependencyInjection/FlysystemExtension.php
+++ b/src/DependencyInjection/FlysystemExtension.php
@@ -30,7 +30,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FlysystemExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/FlysystemBundle.php
+++ b/src/FlysystemBundle.php
@@ -25,7 +25,7 @@ class FlysystemBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 


### PR DESCRIPTION
Hello !
When creating tests for my Symfony bundle that use Flysystem Bundle, I'm having these deprecation notices:
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/86676740/230329780-383e01de-1caf-4942-a91f-b76c72184036.png">

This pull request add missing type declarations to these methods.

