### PR TITLE
Add the possibility to configure default visibility for directories

### DIFF
--- a/src/Adapter/Builder/LocalAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/LocalAdapterDefinitionBuilder.php
@@ -13,9 +13,9 @@ namespace League\FlysystemBundle\Adapter\Builder;
 
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
+use League\Flysystem\Visibility;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use League\Flysystem\Visibility;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>

--- a/src/Adapter/Builder/LocalAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/LocalAdapterDefinitionBuilder.php
@@ -83,6 +83,7 @@ class LocalAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
                     'private' => (int) $options['permissions']['dir']['private'],
                 ],
             ])
+            ->addArgument($options['default_for_directories'] ?? Visibility::PRIVATE)
             ->setShared(false)
         );
         $definition->setArgument(2, $options['lock']);

--- a/src/Adapter/Builder/LocalAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/LocalAdapterDefinitionBuilder.php
@@ -15,6 +15,7 @@ use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use League\Flysystem\Visibility;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>


### PR DESCRIPTION
Currently it's not possible to configure the default visibility for directories.
This could cause some unexpected behavior, e.g. when the root directory of the local storage doesn't exist, it get's created, but using the default visibility and not the configured `directory_visibility` of the storage. 

With this PR it's at least possible to set the default visibility for the storage. 

This could be considered as a follow up to https://github.com/thephpleague/flysystem-bundle/pull/69