### PR TITLE
Added missing connectivityChecker configuration

### DIFF
--- a/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/SftpAdapterDefinitionBuilder.php
@@ -16,6 +16,7 @@ use League\Flysystem\PhpseclibV2\SftpConnectionProvider as SftpConnectionProvide
 use League\Flysystem\PhpseclibV3\SftpAdapter;
 use League\Flysystem\PhpseclibV3\SftpConnectionProvider;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -85,6 +86,9 @@ class SftpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
 
         $resolver->setDefault('permPublic', 0744);
         $resolver->setAllowedTypes('permPublic', 'scalar');
+
+        $resolver->setDefault('connectivityChecker', null);
+        $resolver->setAllowedTypes('connectivityChecker', ['string', 'null']);
     }
 
     protected function configureDefinition(Definition $definition, array $options)
@@ -95,6 +99,10 @@ class SftpAdapterDefinitionBuilder extends AbstractAdapterDefinitionBuilder
         if (class_exists(SftpAdapterLegacy::class)) {
             $adapterFqcn = SftpAdapterLegacy::class;
             $connectionFqcn = SftpConnectionProviderLegacy::class;
+        }
+
+        if ($options['connectivityChecker']) {
+            $options['connectivityChecker'] = new Reference($options['connectivityChecker']);
         }
 
         $definition->setClass($adapterFqcn);

--- a/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
@@ -39,6 +39,7 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
             'passphrase' => null,
             'hostFingerprint' => null,
             'timeout' => 30,
+            'connectivityChecker' => null,
         ]];
     }
 

--- a/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
@@ -39,7 +39,6 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
             'passphrase' => null,
             'hostFingerprint' => null,
             'timeout' => 30,
-            'connectivityChecker' => null,
         ]];
     }
 


### PR DESCRIPTION
This fix allows to customize connectivityChecker (see `\League\Flysystem\PhpseclibV3\SftpConnectionProvider::__construct()`):
```
flysystem:
    storages:
        flysystem.storage.my_storage.sftp:
            adapter: 'sftp'
            options:
                host: ***
                port: ***
                username: ***
                password: ***
                timeout: 10
                connectivityChecker: My\Custom\ConnectivityChecker
```
where `My\Custom\ConnectivityChecker` - is ID of the registered service.