### PR TITLE
Fix Symfony deprecations

### DIFF
--- a/src/DependencyInjection/Compiler/LazyFactoryPass.php
+++ b/src/DependencyInjection/Compiler/LazyFactoryPass.php
@@ -26,7 +26,7 @@ class LazyFactoryPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $factories = [];
         foreach ($container->findTaggedServiceIds('flysystem.storage') as $serviceId => $tags) {

--- a/src/DependencyInjection/FlysystemExtension.php
+++ b/src/DependencyInjection/FlysystemExtension.php
@@ -30,7 +30,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FlysystemExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
@@ -43,7 +43,7 @@ class FlysystemExtension extends Extension
         $this->createStoragesDefinitions($config, $container);
     }
 
-    private function createStoragesDefinitions(array $config, ContainerBuilder $container)
+    private function createStoragesDefinitions(array $config, ContainerBuilder $container): void
     {
         $definitionFactory = new AdapterDefinitionFactory();
 
@@ -82,7 +82,7 @@ class FlysystemExtension extends Extension
         }
     }
 
-    private function createLazyStorageDefinition(string $storageName, array $options)
+    private function createLazyStorageDefinition(string $storageName, array $options): Definition
     {
         $resolver = new OptionsResolver();
         $resolver->setRequired('source');

--- a/src/FlysystemBundle.php
+++ b/src/FlysystemBundle.php
@@ -25,7 +25,7 @@ class FlysystemBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 


### PR DESCRIPTION
- Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "League\FlysystemBundle\FlysystemBundle" now to avoid errors or add an explicit `@return` annotation to suppress this message.
- Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "League\FlysystemBundle\DependencyInjection\FlysystemExtension" now to avoid errors or add an explicit `@return` annotation to suppress this message.
- Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "League\FlysystemBundle\DependencyInjection\Compiler\LazyFactoryPass" now to avoid errors or add an explicit `@return` annotation to suppress this message.