### PR TITLE
Add return type

### DIFF
--- a/src/FlysystemBundle.php
+++ b/src/FlysystemBundle.php
@@ -25,7 +25,7 @@ class FlysystemBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 


### PR DESCRIPTION
Fixes #145

Symfony deprecation

Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "League\FlysystemBundle\FlysystemBundle" now to avoid errors or add an explicit @return annotation to suppress this message.