### PR TITLE
Remove deprecation notices on Symfony 6.3

### DIFF
--- a/src/DependencyInjection/Compiler/LazyFactoryPass.php
+++ b/src/DependencyInjection/Compiler/LazyFactoryPass.php
@@ -25,6 +25,8 @@ class LazyFactoryPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function process(ContainerBuilder $container)
     {

--- a/src/DependencyInjection/FlysystemExtension.php
+++ b/src/DependencyInjection/FlysystemExtension.php
@@ -30,6 +30,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FlysystemExtension extends Extension
 {
+    /**
+     * @return void
+     */
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();


### PR DESCRIPTION
On Symfony 7 will be required to add return types.