### PR TITLE
Switch to non-deprecated Extension class

### DIFF
--- a/src/DependencyInjection/FlysystemExtension.php
+++ b/src/DependencyInjection/FlysystemExtension.php
@@ -21,8 +21,8 @@ use League\FlysystemBundle\Exception\MissingPackageException;
 use League\FlysystemBundle\Lazy\LazyFactory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**


### PR DESCRIPTION
The usage of the `Extension` base class from the HttpKernel component which this bundle uses has been deprecated in Symfony 7.1. This can be resolved by extending the `Extension` class from the DependencyInjection component instead.

This might technically be a small BC break because a `FlysystemExtension` instance wouldn't pass an `instanceof` check for the old extension class anymore, but I think that's acceptable.