### PR TITLE
Fix user provided file/dir permission settings

### DIFF
--- a/src/Adapter/Builder/AbstractAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/AbstractAdapterDefinitionBuilder.php
@@ -70,12 +70,12 @@ abstract class AbstractAdapterDefinitionBuilder implements AdapterDefinitionBuil
             ->setFactory([PortableVisibilityConverter::class, 'fromArray'])
             ->addArgument([
                 'file' => [
-                    'public' => (int) $permissions['file']['public'],
-                    'private' => (int) $permissions['file']['private'],
+                    'public' => intval($permissions['file']['public'],8),
+                    'private' => intval($permissions['file']['private'],8),
                 ],
                 'dir' => [
-                    'public' => (int) $permissions['dir']['public'],
-                    'private' => (int) $permissions['dir']['private'],
+                    'public' => intval($permissions['dir']['public'], 8),
+                    'private' => intval($permissions['dir']['private'], 8),
                 ],
             ])
             ->addArgument($defaultVisibilityForDirectories)

--- a/src/Adapter/Builder/AbstractAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/AbstractAdapterDefinitionBuilder.php
@@ -70,8 +70,8 @@ abstract class AbstractAdapterDefinitionBuilder implements AdapterDefinitionBuil
             ->setFactory([PortableVisibilityConverter::class, 'fromArray'])
             ->addArgument([
                 'file' => [
-                    'public' => intval($permissions['file']['public'],8),
-                    'private' => intval($permissions['file']['private'],8),
+                    'public' => intval($permissions['file']['public'], 8),
+                    'private' => intval($permissions['file']['private'], 8),
                 ],
                 'dir' => [
                     'public' => intval($permissions['dir']['public'], 8),


### PR DESCRIPTION
retain user provided file/dir permissions like 0775 or "0775" as octal int. Converting them with (int) yields incorrect values, as the value is a string at this moment and `(int) "0775"`  will convert to 775 instead to 0775 (509 in decimal), resulting in some interesting file permissions later.