### PR TITLE
feat: Allow custom adapter registration

### DIFF
--- a/src/Adapter/AdapterDefinitionFactory.php
+++ b/src/Adapter/AdapterDefinitionFactory.php
@@ -26,9 +26,12 @@ final class AdapterDefinitionFactory
      */
     private array $builders;
 
-    public function __construct()
+    /**
+     * @param list<AdapterDefinitionBuilderInterface> $builders
+     */
+    public function __construct(array $builders)
     {
-        $this->builders = [
+        $this->builders = array_merge([
             new Builder\AsyncAwsAdapterDefinitionBuilder(),
             new Builder\AwsAdapterDefinitionBuilder(),
             new Builder\AzureAdapterDefinitionBuilder(),
@@ -40,7 +43,7 @@ final class AdapterDefinitionFactory
             new Builder\SftpAdapterDefinitionBuilder(),
             new Builder\WebDAVAdapterDefinitionBuilder(),
             new Builder\BunnyCDNAdapterDefinitionBuilder(),
-        ];
+        ], $builders);
     }
 
     public function createDefinition(string $name, array $options, ?string $defaultVisibilityForDirectories = null): ?Definition

--- a/src/Adapter/Builder/AbstractAdapterDefinitionBuilder.php
+++ b/src/Adapter/Builder/AbstractAdapterDefinitionBuilder.php
@@ -18,8 +18,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @internal
  */
 abstract class AbstractAdapterDefinitionBuilder implements AdapterDefinitionBuilderInterface
 {

--- a/src/Adapter/Builder/AdapterDefinitionBuilderInterface.php
+++ b/src/Adapter/Builder/AdapterDefinitionBuilderInterface.php
@@ -15,8 +15,6 @@ use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @internal
  */
 interface AdapterDefinitionBuilderInterface
 {

--- a/src/DependencyInjection/FlysystemExtension.php
+++ b/src/DependencyInjection/FlysystemExtension.php
@@ -17,6 +17,7 @@ use League\Flysystem\FilesystemReader;
 use League\Flysystem\FilesystemWriter;
 use League\Flysystem\ReadOnly\ReadOnlyFilesystemAdapter;
 use League\FlysystemBundle\Adapter\AdapterDefinitionFactory;
+use League\FlysystemBundle\Adapter\Builder\AdapterDefinitionBuilderInterface;
 use League\FlysystemBundle\Exception\MissingPackageException;
 use League\FlysystemBundle\Lazy\LazyFactory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -30,6 +31,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class FlysystemExtension extends Extension
 {
+    /** @var list<AdapterDefinitionBuilderInterface> */
+    private array $adapterDefinitionBuilders = [];
+
     public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
@@ -43,9 +47,14 @@ final class FlysystemExtension extends Extension
         $this->createStoragesDefinitions($config, $container);
     }
 
+    public function addAdapterDefinitionBuilder(AdapterDefinitionBuilderInterface $builder): void
+    {
+        $this->adapterDefinitionBuilders[] = $builder;
+    }
+
     private function createStoragesDefinitions(array $config, ContainerBuilder $container): void
     {
-        $definitionFactory = new AdapterDefinitionFactory();
+        $definitionFactory = new AdapterDefinitionFactory($this->adapterDefinitionBuilders);
 
         foreach ($config['storages'] as $storageName => $storageConfig) {
             // If the storage is a lazy one, it's resolved at runtime

--- a/tests/Adapter/AdapterDefinitionFactoryTest.php
+++ b/tests/Adapter/AdapterDefinitionFactoryTest.php
@@ -32,7 +32,7 @@ class AdapterDefinitionFactoryTest extends TestCase
      */
     public function testCreateDefinition($name, $options): void
     {
-        $factory = new AdapterDefinitionFactory();
+        $factory = new AdapterDefinitionFactory([]);
 
         $definition = $factory->createDefinition($name, $options);
         $this->assertInstanceOf(Definition::class, $definition);


### PR DESCRIPTION
This PR implements a solution to the issue discussed in #181, enabling external bundles to register their custom storage adapters with Flysystem Bundle without requiring them to be directly added to the main bundle's codebase.

I had to remove the  `@internal` annotation from `AdapterDefinitionBuilderInterface` and `AbstractAdapterDefinitionBuilder` to allow them to be referenced by other bundles.

## Usage Example
External bundles can now register their adapters as follows:
``` php
class AzureBlobStorageAdapterBundle extends Bundle
{
    /**
     * {@inheritdoc}
     */
    public function build(ContainerBuilder $container): void
    {
        parent::build($container);

        /** @var FlysystemExtension $extension */
        $extension = $container->getExtension('flysystem');
        $extension->addAdapterDefinitionBuilder(new AzureOssAdapterDefinitionBuilder());
    }
}
```

If you think this is the right approach I can add a test to my PR.