### PR TITLE
Setup mongodb extension v1.21 for phpunit tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,6 +57,7 @@ jobs:
               with:
                 coverage: none
                 php-version: ${{ matrix.php-version }}
+                extensions: mongodb-1.21.0
 
             - name: Install Symfony Flex
               run: |


### PR DESCRIPTION
MongoDB PHP extension was released with version 2.0.0 and now composer install fails because of `league/flysystem-gridfs` requires `"ext-mongodb": "^1.3"`

This is required until new version of `league/flysystem-gridfs` with support for mongodb 2.0 will be tagged