### PR TITLE
feat: Support Symfony 8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,7 @@ jobs:
                 symfony-version:
                     - '5.4.*'
                     - '6.4.*'
+                    - '7.3.*'
                     - '7.4.*'
                     - '8.0.*'
                 include:
@@ -43,10 +44,7 @@ jobs:
                     - php-version: '8.2'
                       symfony-version: '6.4.*'
                     - php-version: '8.2'
-                      symfony-version: '7.4.*'
-                    - php-version: '8.4'
-                      symfony-version: '8.0.*'
-
+                      symfony-version: '7.3.*'
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -62,6 +60,11 @@ jobs:
               run: |
                   composer config --global --no-plugins allow-plugins.symfony/flex true
                   composer global require --no-progress --no-scripts --no-plugins symfony/flex
+
+            - name: Remove incompatible packages
+              if: matrix.symfony-version == '8.0.*'
+              run: |
+                  composer remove --no-update --dev doctrine/mongodb-odm
 
             - name: Install Composer dependencies
               uses: ramsey/composer-install@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,22 +31,21 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - '8.1'
-                    - '8.2'
-                    - '8.3'
+                    - '8.4'
                 symfony-version:
                     - '5.4.*'
-                    - '6.0.*'
-                    - '6.1.*'
-                    - '6.2.*'
-                    - '6.3.*'
+                    - '6.4.*'
+                    - '7.4.*'
+                    - '8.0.*'
                 include:
                     - php-version: '8.0'
                       symfony-version: '5.4.*'
                     - php-version: '8.2'
                       symfony-version: '6.4.*'
                     - php-version: '8.2'
-                      symfony-version: '7.0.*'
+                      symfony-version: '7.4.*'
+                    - php-version: '8.4'
+                      symfony-version: '8.0.*'
 
         steps:
             - name: Checkout code
@@ -66,6 +65,8 @@ jobs:
 
             - name: Install Composer dependencies
               uses: ramsey/composer-install@v2
+              with:
+                dependency-versions: highest
 
             - name: Run PHPUnit
               run: vendor/bin/simple-phpunit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,6 @@ jobs:
               with:
                 coverage: none
                 php-version: ${{ matrix.php-version }}
-                extensions: mongodb-1.21.0
 
             - name: Install Symfony Flex
               run: |

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
     "require": {
         "php": ">=8.0",
         "league/flysystem": "^3.0",
-        "symfony/config": "^5.4 || ^6.0 || ^7.0",
+        "symfony/config": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/deprecation-contracts": "^2.1 || ^3",
-        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
-        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
-        "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0"
+        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "doctrine/mongodb-odm": "^2.0",
@@ -47,10 +47,10 @@
         "league/flysystem-sftp-v3": "^3.1",
         "league/flysystem-webdav": "^3.29",
         "platformcommunity/flysystem-bunnycdn": "^3.3",
-        "symfony/dotenv": "^5.4 || ^6.0 || ^7.0",
-        "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
-        "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0",
-        "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0"
+        "symfony/dotenv": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0 || ^8.0",
     },
     "config": {
         "preferred-install": {
@@ -58,5 +58,6 @@
         },
         "sort-packages": true
     },
-    "minimum-stability": "beta"
+    "minimum-stability": "dev",
+    "prefer-stable": false
 }

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "symfony/dotenv": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0 || ^8.0",
-        "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0 || ^8.0"
     },
     "config": {
         "preferred-install": {

--- a/tests/Adapter/Builder/GridFSAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/GridFSAdapterDefinitionBuilderTest.php
@@ -98,6 +98,10 @@ class GridFSAdapterDefinitionBuilderTest extends TestCase
 
     public function testInitializeBucketFromDocumentManager(): void
     {
+        if (!class_exists(DocumentManager::class)) {
+            self::markTestSkipped('Doctrine ODM is not installed, skipping test.');
+        }
+
         $client = new Client();
         $config = new Configuration();
         $config->setDefaultDB('testing');


### PR DESCRIPTION
Symfony 8.0 is scheduled for November 2025, adding the upcoming version early in order to spot incompatibilities and ease updates of the ecosystem.

Requirements:

- [x] https://github.com/thephpleague/flysystem-bundle/pull/189
- [x] https://github.com/thephpleague/flysystem-bundle/pull/190
- [x] https://github.com/thephpleague/flysystem-bundle/pull/191

MongoDB ODM tests are skipped, Symfony 8 is not supported yet: https://github.com/doctrine/mongodb-odm/pull/2791