### PR TITLE
fix: Update PHP-CS-Fixer and fix implicit nullable

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,11 +15,11 @@ jobs:
             - uses: actions/checkout@v3
             - uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.0'
+                  php-version: '8.4'
                   coverage: none
             - name: php-cs-fixer
               run: |
-                  wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.13.2/php-cs-fixer.phar -q
+                  wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.85.1/php-cs-fixer.phar -q
                   php php-cs-fixer.phar fix --dry-run --diff
 
     phpunit:

--- a/src/DependencyInjection/Compiler/GcloudFactoryPass.php
+++ b/src/DependencyInjection/Compiler/GcloudFactoryPass.php
@@ -13,9 +13,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 final class GcloudFactoryPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function process(ContainerBuilder $container): void
     {
         if (!class_exists(GoogleCloudStorageAdapter::class)) {

--- a/src/DependencyInjection/Compiler/LazyFactoryPass.php
+++ b/src/DependencyInjection/Compiler/LazyFactoryPass.php
@@ -23,9 +23,6 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 final class LazyFactoryPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function process(ContainerBuilder $container): void
     {
         $factories = [];

--- a/src/Exception/MissingPackageException.php
+++ b/src/Exception/MissingPackageException.php
@@ -16,7 +16,7 @@ namespace League\FlysystemBundle\Exception;
  */
 final class MissingPackageException extends \RuntimeException
 {
-    public function __construct(string $message = '', \Throwable $previous = null)
+    public function __construct(string $message = '', ?\Throwable $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/src/FlysystemBundle.php
+++ b/src/FlysystemBundle.php
@@ -21,9 +21,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class FlysystemBundle extends Bundle
 {
-    /**
-     * {@inheritdoc}
-     */
     public function build(ContainerBuilder $container): void
     {
         parent::build($container);


### PR DESCRIPTION
Update PHP-CS-Fixer to v3.85.1, which is compatible with PHP 8.4.
It detected an implicit nullable parameter (deprecated in PHP 8.4).