### PR TITLE
chore: Make data providers static

### DIFF
--- a/tests/Adapter/AdapterDefinitionFactoryTest.php
+++ b/tests/Adapter/AdapterDefinitionFactoryTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class AdapterDefinitionFactoryTest extends TestCase
 {
-    public function provideConfigOptions(): \Generator
+    public static function provideConfigOptions(): \Generator
     {
         $config = Yaml::parseFile(__DIR__.'/options.yaml');
 

--- a/tests/Adapter/Builder/AsyncAwsAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/AsyncAwsAdapterDefinitionBuilderTest.php
@@ -24,7 +24,7 @@ class AsyncAwsAdapterDefinitionBuilderTest extends TestCase
         return new AsyncAwsAdapterDefinitionBuilder();
     }
 
-    public function provideValidOptions(): \Generator
+    public static function provideValidOptions(): \Generator
     {
         yield 'minimal' => [[
             'client' => 'my_client',

--- a/tests/Adapter/Builder/AwsAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/AwsAdapterDefinitionBuilderTest.php
@@ -24,7 +24,7 @@ class AwsAdapterDefinitionBuilderTest extends TestCase
         return new AwsAdapterDefinitionBuilder();
     }
 
-    public function provideValidOptions(): \Generator
+    public static function provideValidOptions(): \Generator
     {
         yield 'minimal' => [[
             'client' => 'my_client',

--- a/tests/Adapter/Builder/AzureAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/AzureAdapterDefinitionBuilderTest.php
@@ -23,7 +23,7 @@ class AzureAdapterDefinitionBuilderTest extends TestCase
         return new AzureAdapterDefinitionBuilder();
     }
 
-    public function provideValidOptions(): \Generator
+    public static function provideValidOptions(): \Generator
     {
         yield 'minimal' => [[
             'client' => 'my_client',

--- a/tests/Adapter/Builder/FtpAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/FtpAdapterDefinitionBuilderTest.php
@@ -23,7 +23,7 @@ class FtpAdapterDefinitionBuilderTest extends TestCase
         return new FtpAdapterDefinitionBuilder();
     }
 
-    public function provideValidOptions(): \Generator
+    public static function provideValidOptions(): \Generator
     {
         yield 'minimal' => [[
             'host' => 'ftp.example.com',

--- a/tests/Adapter/Builder/GcloudAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/GcloudAdapterDefinitionBuilderTest.php
@@ -26,7 +26,7 @@ class GcloudAdapterDefinitionBuilderTest extends TestCase
         return new GcloudAdapterDefinitionBuilder();
     }
 
-    public function provideValidOptions(): \Generator
+    public static function provideValidOptions(): \Generator
     {
         yield 'minimal' => [[
             'client' => 'my_client',

--- a/tests/Adapter/Builder/LocalAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/LocalAdapterDefinitionBuilderTest.php
@@ -23,7 +23,7 @@ class LocalAdapterDefinitionBuilderTest extends TestCase
         return new LocalAdapterDefinitionBuilder();
     }
 
-    public function provideValidOptions(): \Generator
+    public static function provideValidOptions(): \Generator
     {
         yield 'minimal' => [[
             'directory' => __DIR__,

--- a/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
+++ b/tests/Adapter/Builder/SftpAdapterDefinitionBuilderTest.php
@@ -23,7 +23,7 @@ class SftpAdapterDefinitionBuilderTest extends TestCase
         return new SftpAdapterDefinitionBuilder();
     }
 
-    public function provideValidOptions(): \Generator
+    public static function provideValidOptions(): \Generator
     {
         yield 'minimal' => [[
             'host' => 'ftp.example.com',

--- a/tests/DependencyInjection/FlysystemExtensionTest.php
+++ b/tests/DependencyInjection/FlysystemExtensionTest.php
@@ -24,7 +24,7 @@ use Tests\League\FlysystemBundle\Kernel\FlysystemAppKernel;
 
 class FlysystemExtensionTest extends TestCase
 {
-    public function provideFilesystems(): \Generator
+    public static function provideFilesystems(): \Generator
     {
         $fsNames = [
             'fs_aws',

--- a/tests/FlysystemBundleTest.php
+++ b/tests/FlysystemBundleTest.php
@@ -18,7 +18,7 @@ use Tests\League\FlysystemBundle\Kernel\FrameworkAppKernel;
 
 class FlysystemBundleTest extends TestCase
 {
-    public function provideKernels(): \Generator
+    public static function provideKernels(): \Generator
     {
         yield 'empty' => [new EmptyAppKernel('test', true)];
         yield 'framework' => [new FrameworkAppKernel('test', true)];


### PR DESCRIPTION
PHPUnit 10 deprecated non-static data providers (see https://github.com/sebastianbergmann/phpunit/commit/9caafe2d49b33a21f87db248a8ad6ca7c7bdac09).