### PR TITLE
Use `shivammathur/setup-php` tools

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,10 +17,10 @@ jobs:
               with:
                   php-version: '8.4'
                   coverage: none
+                  tools: php-cs-fixer
             - name: php-cs-fixer
               run: |
-                  wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.85.1/php-cs-fixer.phar -q
-                  php php-cs-fixer.phar fix --dry-run --diff
+                  php-cs-fixer fix --dry-run --diff
 
     phpunit:
         name: PHPUnit (PHP ${{ matrix.php-version }} - Symfony ${{ matrix.symfony-version }})
@@ -57,12 +57,7 @@ jobs:
               with:
                 coverage: none
                 php-version: ${{ matrix.php-version }}
-                extensions: mongodb-1.21.0
-
-            - name: Install Symfony Flex
-              run: |
-                  composer config --global --no-plugins allow-plugins.symfony/flex true
-                  composer global require --no-progress --no-scripts --no-plugins symfony/flex
+                tools: flex
 
             - name: Install Composer dependencies
               uses: ramsey/composer-install@v2


### PR DESCRIPTION
`php-cs-fixer` and `flex` can be installed by the `shivammathur/setup-php` action ([doc](https://github.com/shivammathur/setup-php/blob/main/README.md#wrench-tools-support)).

This reduces the maintenance needs.