### PR TITLE
Allow configuring retain_visibility on Filesystem

### DIFF
--- a/docs/2-cloud-storage-providers.md
+++ b/docs/2-cloud-storage-providers.md
@@ -161,7 +161,7 @@ flysystem:
 ## Cloudflare R2
 
 The Cloudflare R2 is compatible with the AWS S3 API, meaning that you can use the same configuration
-as for an AWS storage. For example:
+as for an AWS storage. Both the regular and the async AWS Client can be used. As example:
 
 ```yaml
 # config/packages/flysystem.yaml
@@ -182,6 +182,23 @@ flysystem:
             options:
                 client: 'cloudflare_r2_client'
                 bucket: '%env(CLOUDFLARE_R2_BUCKET)%'
+```
+
+Cloudflare R2 does not have implemented ACL-related features yet, and thereby making use of Flysystem's `move` and `copy` 
+methods requires configuring explicit value for `visibility` and setting `retain_visibility` to `false` to prevent the 
+S3 adapter to call the `GetObjectAcl` command to retrieve an object's current ACL visibility, then resulting in an exception.
+
+```yaml
+flysystem:
+    storages:
+        cdn.storage:
+            # ...
+            visibility: private # or public
+            
+            # to use the visibility as defined above instead of retaining the object's visibility, and not having to run
+            # the unsupported `GetObjectAcl` command to get the object's current visibility.
+            retain_visibility: false  
+            # ...
 ```
 
 ## Next

--- a/docs/2-cloud-storage-providers.md
+++ b/docs/2-cloud-storage-providers.md
@@ -161,7 +161,7 @@ flysystem:
 ## Cloudflare R2
 
 The Cloudflare R2 is compatible with the AWS S3 API, meaning that you can use the same configuration
-as for a AWS storage. For example:
+as for an AWS storage. For example:
 
 ```yaml
 # config/packages/flysystem.yaml

--- a/docs/B-configuration-reference.md
+++ b/docs/B-configuration-reference.md
@@ -52,7 +52,7 @@ flysystem:
                         private: 0o700
             visibility: ~ # default null. Possible values are 'public' or 'private'
             directory_visibility: ~ # default null. Possible values are 'public' or 'private'
-            retain_visibility: ~ # default null. When set to `true` or `null`, it will lead to adapters performing visibility checks (e.g. GetObjectAcl command for S3 adapters), hence `false` prevents retrieving an object's current visibility
+            retain_visibility: ~ # default null. When set to `true` or `null`, it will lead to adapters performing visibility checks (e.g. GetObjectAcl command for S3 adapters) on copy and move actions, hence `false` prevents retrieving an object's current visibility and use the value as set in `visibility` instead
             case_sensitive: true
             disable_asserts: false
 

--- a/docs/B-configuration-reference.md
+++ b/docs/B-configuration-reference.md
@@ -52,7 +52,7 @@ flysystem:
                         private: 0o700
             visibility: ~ # default null. Possible values are 'public' or 'private'
             directory_visibility: ~ # default null. Possible values are 'public' or 'private'
-            retain_visibility: true # default true, will then lead to adapters performing visibility checks (e.g. GetObjectAcl command for S3 adapters)
+            retain_visibility: ~ # default null. When set to `true` or `null`, it will lead to adapters performing visibility checks (e.g. GetObjectAcl command for S3 adapters), hence `false` prevents retrieving an object's current visibility
             case_sensitive: true
             disable_asserts: false
 

--- a/docs/B-configuration-reference.md
+++ b/docs/B-configuration-reference.md
@@ -52,6 +52,7 @@ flysystem:
                         private: 0o700
             visibility: ~ # default null. Possible values are 'public' or 'private'
             directory_visibility: ~ # default null. Possible values are 'public' or 'private'
+            retain_visibility: true # default true, will then lead to adapters performing visibility checks (e.g. GetObjectAcl command for S3 adapters)
             case_sensitive: true
             disable_asserts: false
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -42,7 +42,7 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('visibility')->defaultNull()->end()
                             ->scalarNode('directory_visibility')->defaultNull()->end()
-                            ->booleanNode('retain_visibility')->defaultTrue()->end()
+                            ->booleanNode('retain_visibility')->defaultNull()->end()
                             ->booleanNode('case_sensitive')->defaultTrue()->end()
                             ->booleanNode('disable_asserts')->defaultFalse()->end()
                             ->arrayNode('public_url')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -42,6 +42,7 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('visibility')->defaultNull()->end()
                             ->scalarNode('directory_visibility')->defaultNull()->end()
+                            ->booleanNode('retain_visibility')->defaultTrue()->end()
                             ->booleanNode('case_sensitive')->defaultTrue()->end()
                             ->booleanNode('disable_asserts')->defaultFalse()->end()
                             ->arrayNode('public_url')

--- a/src/DependencyInjection/FlysystemExtension.php
+++ b/src/DependencyInjection/FlysystemExtension.php
@@ -124,6 +124,7 @@ final class FlysystemExtension extends Extension
         $definition->setArgument(1, [
             'visibility' => $config['visibility'],
             'directory_visibility' => $config['directory_visibility'],
+            'retain_visibility' => $config['retain_visibility'],
             'case_sensitive' => $config['case_sensitive'],
             'disable_asserts' => $config['disable_asserts'],
             'public_url' => $publicUrl,

--- a/tests/DependencyInjection/FlysystemExtensionTest.php
+++ b/tests/DependencyInjection/FlysystemExtensionTest.php
@@ -15,6 +15,7 @@ use AsyncAws\S3\S3Client as AsyncS3Client;
 use Aws\S3\S3Client;
 use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\StorageClient;
+use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\UnableToWriteFile;
 use MicrosoftAzure\Storage\Blob\BlobRestProxy;
@@ -116,6 +117,28 @@ class FlysystemExtensionTest extends TestCase
         $this->expectExceptionMessage('Unable to write file at location: path/to/file. This is a readonly adapter.');
 
         $fs->write('/path/to/file', 'Unable to write in read only');
+    }
+
+    public function testNotRetainingVisibilityPreventsAclCommandInvocation(): void
+    {
+        $kernel = $this->createFlysystemKernel();
+        $container = $kernel->getContainer()->get('test.service_container');
+
+        $calledGetObjectAcl = false;
+
+        /** @var S3Client $mock */
+        $mock = $container->get('aws_client_service');
+        $mock->method('getCommand')->with($this->callback(function ($name) use (&$calledGetObjectAcl) {
+            if ('GetObjectAcl' === $name) {
+                $calledGetObjectAcl = true;
+            }
+        }));
+
+        /** @var Filesystem $fs */
+        $fs = $container->get('flysystem.test.fs_aws');
+        $fs->copy('test.txt', 'test2.txt');
+
+        self::assertFalse($calledGetObjectAcl, 'The ACL command should not be called when `retain_visibility` is set to `false`.');
     }
 
     private function createFlysystemKernel(): FlysystemAppKernel

--- a/tests/Kernel/config/flysystem.php
+++ b/tests/Kernel/config/flysystem.php
@@ -15,6 +15,8 @@ return static function (ContainerConfigurator $container) {
             ],
             'fs_aws' => [
                 'adapter' => 'aws',
+                'visibility' => 'private',
+                'retain_visibility' => false,
                 'options' => [
                     'client' => 'aws_client_service',
                     'bucket' => '%env(AWS_BUCKET)%',


### PR DESCRIPTION
Follow-up of https://github.com/thephpleague/flysystem/pull/1732 an https://github.com/thephpleague/flysystem/pull/1721

This PR implements `retain_visibility` as configuration values on the bundle.

Without this change, calling `move` or `copy` on a Cloudflare R2 bucket will lead to an exception as ACL methods are not implemented yet.