### PR TITLE
Fix typo in read_only option doc reference

### DIFF
--- a/docs/1-getting-started.md
+++ b/docs/1-getting-started.md
@@ -178,7 +178,7 @@ To achieve this, you need to install the read-only package :
 composer require league/flysystem-read-only
 ```
 
-And then, you can configure your storage with the `readonly` options.
+And then, you can configure your storage with the `read_only` option.
 
 ```yaml
 # config/packages/flysystem.yaml
@@ -189,7 +189,7 @@ flysystem:
             adapter: 'local'
             options:
                 directory: '%kernel.project_dir%/storage/users'
-            readonly: true
+            read_only: true
 ```
 
 With this configuration, any write operation will throw a suitable exception.


### PR DESCRIPTION
I got an error when following the docs:

```
"Unrecognized option "readonly" under "flysystem.storages.legacy.upload.storage". Did you mean "read_only"?"
```

It seems that [the docs](https://github.com/thephpleague/flysystem-bundle/blob/3.x/docs/1-getting-started.md#using-read-only-to-disallow-any-write-operations) refer to `readonly`, but the code to `read_only`. 

- https://github.com/thephpleague/flysystem-bundle/blob/3.x/src/DependencyInjection/Configuration.php#L56
- https://github.com/thephpleague/flysystem-bundle/blob/3.x/src/DependencyInjection/FlysystemExtension.php#L73

This will fix the docs.