### PR TITLE
feat: Improve Flysystem bundle DX with push/pull console commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ Once you have a FilesystemOperator, you can call methods from the
 [Filesystem API](https://flysystem.thephpleague.com/v2/docs/usage/filesystem-api/)
 to interact with your storage.
 
+If you need to transfer files between the local filesystem and one of your configured storages, the bundle also provides two console commands:
+
+```bash
+bin/console flysystem:push <storage> <local-source> [remote-destination]
+bin/console flysystem:pull <storage> <remote-source> [local-destination]
+```
+
+The `<storage>` argument is the configured Flysystem storage name (for example `default.storage`), not the adapter type. When the destination is omitted, the basename of the source path is used.
+
 ## Full documentation
 
 1. [Getting started](docs/1-getting-started.md)

--- a/src/Command/AbstractTransferCommand.php
+++ b/src/Command/AbstractTransferCommand.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of the flysystem-bundle project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\FlysystemBundle\Command;
+
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+abstract class AbstractTransferCommand extends Command
+{
+    public function __construct(private readonly ServiceLocator $storages)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('storage', InputArgument::REQUIRED, 'The configured Flysystem storage name.')
+            ->addArgument('source', InputArgument::REQUIRED, 'The source path to transfer.')
+            ->addArgument('destination', InputArgument::OPTIONAL, 'The destination path. Defaults to the source basename.');
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if (null === $input->getArgument('storage')) {
+            $input->setArgument('storage', $io->askQuestion($this->createStorageQuestion()));
+        }
+
+        if (null === $input->getArgument('source')) {
+            $input->setArgument('source', $io->askQuestion($this->createRequiredQuestion(
+                'What is the source path to transfer?',
+                'The source path cannot be empty.'
+            )));
+        }
+
+        if (null === $input->getArgument('destination')) {
+            $input->setArgument('destination', $io->askQuestion($this->createDestinationQuestion((string) $input->getArgument('source'))));
+        }
+    }
+
+    final protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $storageName = (string) $input->getArgument('storage');
+        $source = (string) $input->getArgument('source');
+        $destination = $input->getArgument('destination');
+        $destination = null === $destination ? basename($source) : (string) $destination;
+
+        try {
+            $storage = $this->getStorage($storageName);
+            $this->transfer($storage, $source, $destination);
+        } catch (InvalidArgumentException|\InvalidArgumentException $exception) {
+            $io->error($exception->getMessage());
+
+            return self::INVALID;
+        } catch (FilesystemException|\RuntimeException $exception) {
+            $io->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $io->success($this->createSuccessMessage($storageName, $source, $destination));
+
+        return self::SUCCESS;
+    }
+
+    private function createStorageQuestion(): Question
+    {
+        $storageNames = array_keys($this->storages->getProvidedServices());
+        sort($storageNames);
+
+        $question = new Question('Which configured Flysystem storage should be used?', 1 === count($storageNames) ? $storageNames[0] : null);
+        $question->setAutocompleterValues($storageNames);
+        $question->setValidator(function (?string $answer): string {
+            $answer = trim((string) $answer);
+
+            if ('' === $answer) {
+                throw new \RuntimeException('The storage name cannot be empty.');
+            }
+
+            if (!$this->storages->has($answer)) {
+                throw new \RuntimeException(sprintf('The storage "%s" does not exist.', $answer));
+            }
+
+            return $answer;
+        });
+
+        return $question;
+    }
+
+    private function createDestinationQuestion(string $source): Question
+    {
+        $question = new Question('What is the destination path?', basename($source));
+        $question->setValidator(function (?string $answer): string {
+            $answer = trim((string) $answer);
+
+            if ('' === $answer) {
+                throw new \RuntimeException('The destination path cannot be empty.');
+            }
+
+            return $answer;
+        });
+
+        return $question;
+    }
+
+    private function createRequiredQuestion(string $label, string $errorMessage): Question
+    {
+        $question = new Question($label);
+        $question->setValidator(function (?string $answer) use ($errorMessage): string {
+            $answer = trim((string) $answer);
+
+            if ('' === $answer) {
+                throw new \RuntimeException($errorMessage);
+            }
+
+            return $answer;
+        });
+
+        return $question;
+    }
+
+    private function getStorage(string $storageName): FilesystemOperator
+    {
+        if (!$this->storages->has($storageName)) {
+            throw new InvalidArgumentException(sprintf('The storage "%s" does not exist.', $storageName));
+        }
+
+        $storage = $this->storages->get($storageName);
+        if (!$storage instanceof FilesystemOperator) {
+            throw new \RuntimeException(sprintf('The storage "%s" is not a Flysystem operator.', $storageName));
+        }
+
+        return $storage;
+    }
+
+    abstract protected function transfer(FilesystemOperator $storage, string $source, string $destination): void;
+
+    abstract protected function createSuccessMessage(string $storageName, string $source, string $destination): string;
+}

--- a/src/Command/AbstractTransferCommand.php
+++ b/src/Command/AbstractTransferCommand.php
@@ -64,6 +64,7 @@ abstract class AbstractTransferCommand extends Command
         $source = (string) $input->getArgument('source');
         $destination = $input->getArgument('destination');
         $destination = null === $destination ? basename($source) : (string) $destination;
+        $destination = $this->normalizeDestination($source, $destination);
 
         try {
             $storage = $this->getStorage($storageName);
@@ -151,6 +152,11 @@ abstract class AbstractTransferCommand extends Command
         }
 
         return $storage;
+    }
+
+    protected function normalizeDestination(string $source, string $destination): string
+    {
+        return $destination;
     }
 
     abstract protected function transfer(FilesystemOperator $storage, string $source, string $destination): void;

--- a/src/Command/AbstractTransferCommand.php
+++ b/src/Command/AbstractTransferCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -34,7 +35,8 @@ abstract class AbstractTransferCommand extends Command
         $this
             ->addArgument('storage', InputArgument::REQUIRED, 'The configured Flysystem storage name.')
             ->addArgument('source', InputArgument::REQUIRED, 'The source path to transfer.')
-            ->addArgument('destination', InputArgument::OPTIONAL, 'The destination path. Defaults to the source basename.');
+            ->addArgument('destination', InputArgument::OPTIONAL, 'The destination path. Defaults to the source basename.')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Overwrite the destination file if it already exists.');
     }
 
     protected function interact(InputInterface $input, OutputInterface $output): void
@@ -66,9 +68,11 @@ abstract class AbstractTransferCommand extends Command
         $destination = null === $destination ? basename($source) : (string) $destination;
         $destination = $this->normalizeDestination($source, $destination);
 
+        $force = (bool) $input->getOption('force');
+
         try {
             $storage = $this->getStorage($storageName);
-            $this->transfer($storage, $source, $destination);
+            $this->transfer($storage, $source, $destination, $force);
         } catch (InvalidArgumentException|\InvalidArgumentException $exception) {
             $io->error($exception->getMessage());
 
@@ -159,7 +163,7 @@ abstract class AbstractTransferCommand extends Command
         return $destination;
     }
 
-    abstract protected function transfer(FilesystemOperator $storage, string $source, string $destination): void;
+    abstract protected function transfer(FilesystemOperator $storage, string $source, string $destination, bool $force = false): void;
 
     abstract protected function createSuccessMessage(string $storageName, string $source, string $destination): string;
 }

--- a/src/Command/PullCommand.php
+++ b/src/Command/PullCommand.php
@@ -52,7 +52,10 @@ final class PullCommand extends AbstractTransferCommand
         }
 
         try {
-            stream_copy_to_stream($resource, $local);
+            $bytesCopied = stream_copy_to_stream($resource, $local);
+            if (false === $bytesCopied) {
+                throw new \RuntimeException(sprintf('Failed to write "%s" to "%s": stream copy failed.', $source, $destination));
+            }
         } finally {
             fclose($resource);
             fclose($local);

--- a/src/Command/PullCommand.php
+++ b/src/Command/PullCommand.php
@@ -26,11 +26,15 @@ final class PullCommand extends AbstractTransferCommand
         return rtrim($destination, '/\\').DIRECTORY_SEPARATOR.basename($source);
     }
 
-    protected function transfer(FilesystemOperator $storage, string $source, string $destination): void
+    protected function transfer(FilesystemOperator $storage, string $source, string $destination, bool $force = false): void
     {
         $directory = dirname($destination);
         if ('.' !== $directory && !is_dir($directory) && !mkdir($directory, 0777, true) && !is_dir($directory)) {
             throw new \RuntimeException(sprintf('Unable to create the destination directory "%s".', $directory));
+        }
+
+        if (!$force && is_file($destination)) {
+            throw new \RuntimeException(sprintf('The destination file "%s" already exists. Use the --force option to overwrite it.', $destination));
         }
 
         $resource = $storage->readStream($source);

--- a/src/Command/PullCommand.php
+++ b/src/Command/PullCommand.php
@@ -29,7 +29,7 @@ final class PullCommand extends AbstractTransferCommand
     protected function transfer(FilesystemOperator $storage, string $source, string $destination, bool $force = false): void
     {
         $directory = dirname($destination);
-        if ('.' !== $directory && !is_dir($directory) && !mkdir($directory, 0777, true) && !is_dir($directory)) {
+        if ('.' !== $directory && !is_dir($directory) && !mkdir($directory, 0755, true) && !is_dir($directory)) {
             throw new \RuntimeException(sprintf('Unable to create the destination directory "%s".', $directory));
         }
 

--- a/src/Command/PullCommand.php
+++ b/src/Command/PullCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the flysystem-bundle project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\FlysystemBundle\Command;
+
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'flysystem:pull', description: 'Pull a file from a configured Flysystem storage to the local filesystem.')]
+final class PullCommand extends AbstractTransferCommand
+{
+    protected function normalizeDestination(string $source, string $destination): string
+    {
+        if (!is_dir($destination)) {
+            return $destination;
+        }
+
+        return rtrim($destination, '/\\').DIRECTORY_SEPARATOR.basename($source);
+    }
+
+    protected function transfer(FilesystemOperator $storage, string $source, string $destination): void
+    {
+        $directory = dirname($destination);
+        if ('.' !== $directory && !is_dir($directory) && !mkdir($directory, 0777, true) && !is_dir($directory)) {
+            throw new \RuntimeException(sprintf('Unable to create the destination directory "%s".', $directory));
+        }
+
+        $resource = $storage->readStream($source);
+        if (!is_resource($resource)) {
+            throw new \RuntimeException(sprintf('Unable to read the source file "%s" from storage.', $source));
+        }
+
+        $local = fopen($destination, 'wb');
+        if (false === $local) {
+            if (is_resource($resource)) {
+                fclose($resource);
+            }
+
+            throw new \RuntimeException(sprintf('Unable to open the destination file "%s" for writing.', $destination));
+        }
+
+        try {
+            stream_copy_to_stream($resource, $local);
+        } finally {
+            fclose($resource);
+            fclose($local);
+        }
+    }
+
+    protected function createSuccessMessage(string $storageName, string $source, string $destination): string
+    {
+        return sprintf('Pulled "%s" from storage "%s" to "%s".', $source, $storageName, $destination);
+    }
+}

--- a/src/Command/PushCommand.php
+++ b/src/Command/PushCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the flysystem-bundle project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\FlysystemBundle\Command;
+
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'flysystem:push', description: 'Push a local file to a configured Flysystem storage.')]
+final class PushCommand extends AbstractTransferCommand
+{
+    protected function transfer(FilesystemOperator $storage, string $source, string $destination): void
+    {
+        if (!is_file($source)) {
+            throw new \InvalidArgumentException(sprintf('The source file "%s" does not exist or is not a regular file.', $source));
+        }
+
+        $resource = fopen($source, 'rb');
+        if (false === $resource) {
+            throw new \RuntimeException(sprintf('Unable to open the source file "%s" for reading.', $source));
+        }
+
+        try {
+            $storage->writeStream($destination, $resource);
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    protected function createSuccessMessage(string $storageName, string $source, string $destination): string
+    {
+        return sprintf('Pushed "%s" to "%s" on storage "%s".', $source, $destination, $storageName);
+    }
+}

--- a/src/Command/PushCommand.php
+++ b/src/Command/PushCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'flysystem:push', description: 'Push a local file to a configured Flysystem storage.')]
 final class PushCommand extends AbstractTransferCommand
 {
-    protected function transfer(FilesystemOperator $storage, string $source, string $destination): void
+    protected function transfer(FilesystemOperator $storage, string $source, string $destination, bool $force = false): void
     {
         if (!is_file($source)) {
             throw new \InvalidArgumentException(sprintf('The source file "%s" does not exist or is not a regular file.', $source));

--- a/src/Command/PushCommand.php
+++ b/src/Command/PushCommand.php
@@ -23,6 +23,10 @@ final class PushCommand extends AbstractTransferCommand
             throw new \InvalidArgumentException(sprintf('The source file "%s" does not exist or is not a regular file.', $source));
         }
 
+        if (!$force && $storage->fileExists($destination)) {
+            throw new \RuntimeException(sprintf('The destination file "%s" already exists on the storage. Use the --force option to overwrite it.', $destination));
+        }
+
         $resource = fopen($source, 'rb');
         if (false === $resource) {
             throw new \RuntimeException(sprintf('Unable to open the source file "%s" for reading.', $source));

--- a/src/DependencyInjection/FlysystemExtension.php
+++ b/src/DependencyInjection/FlysystemExtension.php
@@ -17,13 +17,17 @@ use League\Flysystem\FilesystemReader;
 use League\Flysystem\FilesystemWriter;
 use League\Flysystem\ReadOnly\ReadOnlyFilesystemAdapter;
 use League\FlysystemBundle\Adapter\AdapterDefinitionFactory;
+use League\FlysystemBundle\Command\PushCommand;
 use League\FlysystemBundle\Exception\MissingPackageException;
 use League\FlysystemBundle\Lazy\LazyFactory;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_locator;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
@@ -40,7 +44,21 @@ final class FlysystemExtension extends Extension
             ->setPublic(false)
         ;
 
+        if (ContainerBuilder::willBeAvailable('symfony/console', Command::class, ['symfony/framework-bundle'])) {
+            $this->registerPushCommand($container);
+        }
+
         $this->createStoragesDefinitions($config, $container);
+    }
+
+    private function registerPushCommand(ContainerBuilder $container): void
+    {
+        $container
+            ->register(PushCommand::class, PushCommand::class)
+            ->setPublic(false)
+            ->setArgument('$storages', tagged_locator('flysystem.storage', 'storage'))
+            ->addTag('console.command')
+        ;
     }
 
     private function createStoragesDefinitions(array $config, ContainerBuilder $container): void

--- a/src/DependencyInjection/FlysystemExtension.php
+++ b/src/DependencyInjection/FlysystemExtension.php
@@ -17,6 +17,7 @@ use League\Flysystem\FilesystemReader;
 use League\Flysystem\FilesystemWriter;
 use League\Flysystem\ReadOnly\ReadOnlyFilesystemAdapter;
 use League\FlysystemBundle\Adapter\AdapterDefinitionFactory;
+use League\FlysystemBundle\Command\PullCommand;
 use League\FlysystemBundle\Command\PushCommand;
 use League\FlysystemBundle\Exception\MissingPackageException;
 use League\FlysystemBundle\Lazy\LazyFactory;
@@ -46,6 +47,7 @@ final class FlysystemExtension extends Extension
 
         if (ContainerBuilder::willBeAvailable('symfony/console', Command::class, ['symfony/framework-bundle'])) {
             $this->registerPushCommand($container);
+            $this->registerPullCommand($container);
         }
 
         $this->createStoragesDefinitions($config, $container);
@@ -55,6 +57,16 @@ final class FlysystemExtension extends Extension
     {
         $container
             ->register(PushCommand::class, PushCommand::class)
+            ->setPublic(false)
+            ->setArgument('$storages', tagged_locator('flysystem.storage', 'storage'))
+            ->addTag('console.command')
+        ;
+    }
+
+    private function registerPullCommand(ContainerBuilder $container): void
+    {
+        $container
+            ->register(PullCommand::class, PullCommand::class)
             ->setPublic(false)
             ->setArgument('$storages', tagged_locator('flysystem.storage', 'storage'))
             ->addTag('console.command')

--- a/tests/Command/TransferCommandTest.php
+++ b/tests/Command/TransferCommandTest.php
@@ -19,6 +19,8 @@ use Tests\League\FlysystemBundle\Kernel\FrameworkAppKernel;
 
 class TransferCommandTest extends KernelTestCase
 {
+    private const BASE_DIR = 'flysystem-bundle-command-tests';
+
     private string $storageDirectory;
     private string $workingDirectory;
 
@@ -26,7 +28,7 @@ class TransferCommandTest extends KernelTestCase
     {
         parent::setUp();
 
-        $base = sys_get_temp_dir().'/flysystem-bundle-command-tests';
+        $base = sys_get_temp_dir().'/'.self::BASE_DIR;
         $this->removeDirectory($base);
 
         $this->storageDirectory = $base.'/storage';
@@ -188,7 +190,7 @@ class TransferCommandTest extends KernelTestCase
 
     private static function getStorageDirectory(): string
     {
-        $storageDirectory = sys_get_temp_dir().'/flysystem-bundle-command-tests/storage';
+        $storageDirectory = sys_get_temp_dir().'/'.self::BASE_DIR.'/storage';
 
         if (!is_dir($storageDirectory)) {
             mkdir($storageDirectory, 0755, true);

--- a/tests/Command/TransferCommandTest.php
+++ b/tests/Command/TransferCommandTest.php
@@ -92,6 +92,59 @@ class TransferCommandTest extends KernelTestCase
         self::assertStringContainsString('Pushed', $tester->getDisplay());
     }
 
+    public function testPushCommandFailsWhenDestinationAlreadyExists(): void
+    {
+        self::bootKernel();
+        $application = new Application(self::$kernel);
+        $container = static::getContainer();
+
+        /** @var FilesystemOperator $storage */
+        $storage = $container->get('uploads.storage');
+        $storage->write('existing.txt', 'existing-content');
+
+        $command = $application->find('flysystem:push');
+        $tester = new CommandTester($command);
+
+        file_put_contents($localFile = $this->workingDirectory.'/new.txt', 'new-content');
+
+        $exitCode = $tester->execute([
+            'storage' => 'uploads.storage',
+            'source' => $localFile,
+            'destination' => 'existing.txt',
+        ]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertSame('existing-content', $storage->read('existing.txt'));
+        self::assertStringContainsString('already exists', $tester->getDisplay());
+    }
+
+    public function testPushCommandOverwritesWhenDestinationAlreadyExistsWithForce(): void
+    {
+        self::bootKernel();
+        $application = new Application(self::$kernel);
+        $container = static::getContainer();
+
+        /** @var FilesystemOperator $storage */
+        $storage = $container->get('uploads.storage');
+        $storage->write('existing.txt', 'existing-content');
+
+        $command = $application->find('flysystem:push');
+        $tester = new CommandTester($command);
+
+        file_put_contents($localFile = $this->workingDirectory.'/new.txt', 'new-content');
+
+        $exitCode = $tester->execute([
+            'storage' => 'uploads.storage',
+            'source' => $localFile,
+            'destination' => 'existing.txt',
+            '--force' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertSame('new-content', $storage->read('existing.txt'));
+        self::assertStringContainsString('Pushed', $tester->getDisplay());
+    }
+
     public function testPullCommandPullsAStorageFileToTheLocalFilesystem(): void
     {
         self::bootKernel();

--- a/tests/Command/TransferCommandTest.php
+++ b/tests/Command/TransferCommandTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the flysystem-bundle project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\League\FlysystemBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Tests\League\FlysystemBundle\Kernel\FrameworkAppKernel;
+
+class TransferCommandTest extends KernelTestCase
+{
+    private string $storageDirectory;
+    private string $workingDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $base = sys_get_temp_dir().'/flysystem-bundle-command-tests';
+        $this->removeDirectory($base);
+
+        $this->storageDirectory = $base.'/storage';
+        $this->workingDirectory = $base.'/work';
+
+        mkdir($this->storageDirectory, 0777, true);
+        mkdir($this->workingDirectory, 0777, true);
+    }
+
+    public function testPushCommandPushesALocalFileToTheConfiguredStorage(): void
+    {
+        file_put_contents($localFile = $this->workingDirectory.'/push.txt', 'push-content');
+
+        self::bootKernel();
+        $application = new Application(self::$kernel);
+
+        $command = $application->find('flysystem:push');
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute([
+            'storage' => 'uploads.storage',
+            'source' => $localFile,
+        ]);
+
+        self::assertSame(0, $exitCode);
+        self::assertSame('push-content', file_get_contents($this->storageDirectory.'/push.txt'));
+        self::assertStringContainsString('Pushed', $tester->getDisplay());
+    }
+
+    public function testPushCommandAsksForStorageSourceAndDestinationInteractively(): void
+    {
+        file_put_contents($localFile = $this->workingDirectory.'/interactive-push.txt', 'interactive-push-content');
+        $destination = 'nested/interactive-result.txt';
+
+        self::bootKernel();
+        $application = new Application(self::$kernel);
+
+        $command = $application->find('flysystem:push');
+        $tester = new CommandTester($command);
+        $tester->setInputs([
+            'uploads.storage',
+            $localFile,
+            $destination,
+        ]);
+
+        $exitCode = $tester->execute([], ['interactive' => true]);
+
+        self::assertSame(0, $exitCode);
+        self::assertSame('interactive-push-content', file_get_contents($this->storageDirectory.'/'.$destination));
+        self::assertStringContainsString('Which configured Flysystem storage should be used?', $tester->getDisplay());
+        self::assertStringContainsString('What is the source path to transfer?', $tester->getDisplay());
+        self::assertStringContainsString('What is the destination path?', $tester->getDisplay());
+        self::assertStringContainsString('Pushed', $tester->getDisplay());
+    }
+
+    public function testPushCommandFailsForUnknownStorage(): void
+    {
+        file_put_contents($localFile = $this->workingDirectory.'/push.txt', 'push-content');
+
+        self::bootKernel();
+        $application = new Application(self::$kernel);
+
+        $command = $application->find('flysystem:push');
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute([
+            'storage' => 'unknown.storage',
+            'source' => $localFile,
+        ]);
+
+        self::assertSame(2, $exitCode);
+        self::assertStringContainsString('The storage "unknown.storage" does not exist.', $tester->getDisplay());
+    }
+
+    protected static function createKernel(array $options = []): FrameworkAppKernel
+    {
+        return new FrameworkAppKernel('test', true, self::getStorageDirectory());
+    }
+
+    private static function getStorageDirectory(): string
+    {
+        $storageDirectory = sys_get_temp_dir().'/flysystem-bundle-command-tests/storage';
+
+        if (!is_dir($storageDirectory)) {
+            mkdir($storageDirectory, 0777, true);
+        }
+
+        return $storageDirectory;
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($directory);
+    }
+}

--- a/tests/Command/TransferCommandTest.php
+++ b/tests/Command/TransferCommandTest.php
@@ -39,6 +39,13 @@ class TransferCommandTest extends KernelTestCase
         mkdir($this->workingDirectory, 0755, true);
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->removeDirectory(sys_get_temp_dir().'/'.self::BASE_DIR);
+    }
+
     public function testPushCommandPushesALocalFileToTheConfiguredStorage(): void
     {
         file_put_contents($localFile = $this->workingDirectory.'/push.txt', 'push-content');

--- a/tests/Command/TransferCommandTest.php
+++ b/tests/Command/TransferCommandTest.php
@@ -107,6 +107,61 @@ class TransferCommandTest extends KernelTestCase
         self::assertStringContainsString('Pulled', $tester->getDisplay());
     }
 
+    public function testPullCommandFailsWhenDestinationAlreadyExists(): void
+    {
+        self::bootKernel();
+        $application = new Application(self::$kernel);
+        $container = static::getContainer();
+
+        /** @var FilesystemOperator $storage */
+        $storage = $container->get('uploads.storage');
+        $storage->write('remote.txt', 'pull-content');
+
+        $destination = $this->workingDirectory.'/local.txt';
+        file_put_contents($destination, 'existing-content');
+
+        $command = $application->find('flysystem:pull');
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute([
+            'storage' => 'uploads.storage',
+            'source' => 'remote.txt',
+            'destination' => $destination,
+        ]);
+
+        self::assertSame(1, $exitCode);
+        self::assertSame('existing-content', file_get_contents($destination));
+        self::assertStringContainsString('already exists', $tester->getDisplay());
+    }
+
+    public function testPullCommandOverwritesWhenDestinationAlreadyExistsWithForce(): void
+    {
+        self::bootKernel();
+        $application = new Application(self::$kernel);
+        $container = static::getContainer();
+
+        /** @var FilesystemOperator $storage */
+        $storage = $container->get('uploads.storage');
+        $storage->write('remote.txt', 'pull-content');
+
+        $destination = $this->workingDirectory.'/local.txt';
+        file_put_contents($destination, 'existing-content');
+
+        $command = $application->find('flysystem:pull');
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute([
+            'storage' => 'uploads.storage',
+            'source' => 'remote.txt',
+            'destination' => $destination,
+            '--force' => true,
+        ]);
+
+        self::assertSame(0, $exitCode);
+        self::assertSame('pull-content', file_get_contents($destination));
+        self::assertStringContainsString('Pulled', $tester->getDisplay());
+    }
+
     public function testPushCommandFailsForUnknownStorage(): void
     {
         file_put_contents($localFile = $this->workingDirectory.'/push.txt', 'push-content');

--- a/tests/Command/TransferCommandTest.php
+++ b/tests/Command/TransferCommandTest.php
@@ -14,6 +14,7 @@ namespace Tests\League\FlysystemBundle\Command;
 use League\Flysystem\FilesystemOperator;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Tests\League\FlysystemBundle\Kernel\FrameworkAppKernel;
 
@@ -53,7 +54,7 @@ class TransferCommandTest extends KernelTestCase
             'source' => $localFile,
         ]);
 
-        self::assertSame(0, $exitCode);
+        self::assertSame(Command::SUCCESS, $exitCode);
         self::assertSame('push-content', file_get_contents($this->storageDirectory.'/push.txt'));
         self::assertStringContainsString('Pushed', $tester->getDisplay());
     }
@@ -76,7 +77,7 @@ class TransferCommandTest extends KernelTestCase
 
         $exitCode = $tester->execute([], ['interactive' => true]);
 
-        self::assertSame(0, $exitCode);
+        self::assertSame(Command::SUCCESS, $exitCode);
         self::assertSame('interactive-push-content', file_get_contents($this->storageDirectory.'/'.$destination));
         self::assertStringContainsString('Which configured Flysystem storage should be used?', $tester->getDisplay());
         self::assertStringContainsString('What is the source path to transfer?', $tester->getDisplay());
@@ -104,7 +105,7 @@ class TransferCommandTest extends KernelTestCase
             'destination' => $destination,
         ]);
 
-        self::assertSame(0, $exitCode);
+        self::assertSame(Command::SUCCESS, $exitCode);
         self::assertSame('pull-content', file_get_contents($destination));
         self::assertStringContainsString('Pulled', $tester->getDisplay());
     }
@@ -131,7 +132,7 @@ class TransferCommandTest extends KernelTestCase
             'destination' => $destination,
         ]);
 
-        self::assertSame(1, $exitCode);
+        self::assertSame(Command::FAILURE, $exitCode);
         self::assertSame('existing-content', file_get_contents($destination));
         self::assertStringContainsString('already exists', $tester->getDisplay());
     }
@@ -159,7 +160,7 @@ class TransferCommandTest extends KernelTestCase
             '--force' => true,
         ]);
 
-        self::assertSame(0, $exitCode);
+        self::assertSame(Command::SUCCESS, $exitCode);
         self::assertSame('pull-content', file_get_contents($destination));
         self::assertStringContainsString('Pulled', $tester->getDisplay());
     }
@@ -179,7 +180,7 @@ class TransferCommandTest extends KernelTestCase
             'source' => $localFile,
         ]);
 
-        self::assertSame(2, $exitCode);
+        self::assertSame(Command::INVALID, $exitCode);
         self::assertStringContainsString('The storage "unknown.storage" does not exist.', $tester->getDisplay());
     }
 

--- a/tests/Command/TransferCommandTest.php
+++ b/tests/Command/TransferCommandTest.php
@@ -32,8 +32,8 @@ class TransferCommandTest extends KernelTestCase
         $this->storageDirectory = $base.'/storage';
         $this->workingDirectory = $base.'/work';
 
-        mkdir($this->storageDirectory, 0777, true);
-        mkdir($this->workingDirectory, 0777, true);
+        mkdir($this->storageDirectory, 0755, true);
+        mkdir($this->workingDirectory, 0755, true);
     }
 
     public function testPushCommandPushesALocalFileToTheConfiguredStorage(): void
@@ -191,7 +191,7 @@ class TransferCommandTest extends KernelTestCase
         $storageDirectory = sys_get_temp_dir().'/flysystem-bundle-command-tests/storage';
 
         if (!is_dir($storageDirectory)) {
-            mkdir($storageDirectory, 0777, true);
+            mkdir($storageDirectory, 0755, true);
         }
 
         return $storageDirectory;

--- a/tests/Command/TransferCommandTest.php
+++ b/tests/Command/TransferCommandTest.php
@@ -11,6 +11,7 @@
 
 namespace Tests\League\FlysystemBundle\Command;
 
+use League\Flysystem\FilesystemOperator;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -79,6 +80,31 @@ class TransferCommandTest extends KernelTestCase
         self::assertStringContainsString('What is the source path to transfer?', $tester->getDisplay());
         self::assertStringContainsString('What is the destination path?', $tester->getDisplay());
         self::assertStringContainsString('Pushed', $tester->getDisplay());
+    }
+
+    public function testPullCommandPullsAStorageFileToTheLocalFilesystem(): void
+    {
+        self::bootKernel();
+        $application = new Application(self::$kernel);
+        $container = static::getContainer();
+
+        /** @var FilesystemOperator $storage */
+        $storage = $container->get('uploads.storage');
+        $storage->write('remote.txt', 'pull-content');
+
+        $command = $application->find('flysystem:pull');
+        $tester = new CommandTester($command);
+
+        $destination = $this->workingDirectory.'/nested/local.txt';
+        $exitCode = $tester->execute([
+            'storage' => 'uploads.storage',
+            'source' => 'remote.txt',
+            'destination' => $destination,
+        ]);
+
+        self::assertSame(0, $exitCode);
+        self::assertSame('pull-content', file_get_contents($destination));
+        self::assertStringContainsString('Pulled', $tester->getDisplay());
     }
 
     public function testPushCommandFailsForUnknownStorage(): void

--- a/tests/Kernel/FrameworkAppKernel.php
+++ b/tests/Kernel/FrameworkAppKernel.php
@@ -21,6 +21,11 @@ class FrameworkAppKernel extends Kernel
 {
     use AppKernelTrait;
 
+    public function __construct(string $environment, bool $debug, private readonly string $storageDirectory = __DIR__)
+    {
+        parent::__construct($environment, $debug);
+    }
+
     public function registerBundles(): iterable
     {
         return [new FrameworkBundle(), new FlysystemBundle()];
@@ -28,13 +33,18 @@ class FrameworkAppKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
+        $storageDirectory = $this->storageDirectory;
+
         $loader->load(function (ContainerBuilder $container) {
             $container->loadFromExtension('framework', ['secret' => '$ecret', 'test' => true, 'http_method_override' => false]);
+        });
+
+        $loader->load(function (ContainerBuilder $container) use ($storageDirectory) {
             $container->loadFromExtension('flysystem', [
                 'storages' => [
                     'uploads.storage' => [
                         'adapter' => 'local',
-                        'options' => ['directory' => __DIR__],
+                        'options' => ['directory' => $storageDirectory],
                     ],
                 ],
             ]);


### PR DESCRIPTION
Summary:
This PR adds two native console commands to transfer files between the local filesystem and configured Flysystem storages:
flysystem:push
flysystem:pull
The commands support interactive prompts for missing arguments.

Motivation:
	Applications already configure Flysystem storages through the bundle, but transferring files to or from those storages currently requires ad hoc application code or one-off scripts.
	Providing built-in console commands makes common operational tasks easier:
	manually pushing files to a configured storage
retrieving files from a storage during development or support operations
scripting simple import/export workflows around existing storage definitions
This keeps the workflow close to the bundle itself and avoids duplicating the same logic in userland code.

What is included:
New console commands
This PR introduces two commands:
flysystem:push to upload a local file to a configured storage
flysystem:pull to download a file from a configured storage to the local filesystem
Both commands rely on the existing configured storage names, so they work directly with the storages already declared in bundle configuration.
Conditional command registration
The commands are only registered when Symfony Console is available.

