### PR TITLE
Remove internal annotation from FlysystemBundle

### DIFF
--- a/src/FlysystemBundle.php
+++ b/src/FlysystemBundle.php
@@ -19,8 +19,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * @author Titouan Galopin <galopintitouan@gmail.com>
- *
- * @internal
  */
 final class FlysystemBundle extends Bundle
 {


### PR DESCRIPTION
This class is the library entry point for downstream consumers, thus it must be public.

Fixes: #207