### PR TITLE
docs: fix SFTP permissions configuration example

### DIFF
--- a/docs/3-interacting-with-ftp-and-sftp-servers.md
+++ b/docs/3-interacting-with-ftp-and-sftp-servers.md
@@ -61,9 +61,13 @@ flysystem:
                     hostkey: ['rsa-sha2-256', 'ssh-rsa']
                 root: '/path/to/root'
                 timeout: 10
-                directoryPerm: 0744
-                permPublic: 0700
-                permPrivate: 0744
+                permissions:
+                    file:
+                        public: 0o644
+                        private: 0o600
+                    dir:
+                        public: 0o755
+                        private: 0o700
 ```
 
 ## Next


### PR DESCRIPTION
The SFTP example still uses the `directoryPerm`, `permPublic` and `permPrivate` options, which aren't valid in the current config format, so following the docs throws an "Unrecognized options" error. This updates it to the `permissions` block that replaced them, using `0o` octal values so they're parsed as integers.

Fixes #212